### PR TITLE
Create Log Message when Authentication Type is Invalid

### DIFF
--- a/src/GeneralTools/CDSClient/Client/Utils/CdsConnectionStringProcessor.cs
+++ b/src/GeneralTools/CDSClient/Client/Utils/CdsConnectionStringProcessor.cs
@@ -266,7 +266,7 @@ namespace Microsoft.PowerPlatform.Cds.Client
 			}
 			else
 			{
-				logEntry.Log($"Authentication Type \"{authType}\" is not a valid Authentication Type.");
+				logEntry.Log($"Authentication Type \"{authType}\" is not a valid Authentication Type.", System.Diagnostics.TraceEventType.Error);
 				AuthenticationType = AuthenticationType.InvalidConnection;
 			}
 

--- a/src/GeneralTools/CDSClient/Client/Utils/CdsConnectionStringProcessor.cs
+++ b/src/GeneralTools/CDSClient/Client/Utils/CdsConnectionStringProcessor.cs
@@ -266,6 +266,7 @@ namespace Microsoft.PowerPlatform.Cds.Client
 			}
 			else
 			{
+				logEntry.Log($"Authentication Type \"{authType}\" is not a valid Authentication Type.");
 				AuthenticationType = AuthenticationType.InvalidConnection;
 			}
 


### PR DESCRIPTION
When a connection string's AuthType is invalid (i.e., doesn't parse successfully) that should be written to the logs. Otherwise the only way to know the issue exists is to either manually code such a message or be in the debugger.