### PR TITLE
Queued up bug fixes from pre Rename.  See notes for updates. 

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
+++ b/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
@@ -93,13 +93,9 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		private string _ServiceCACHEName = "Microsoft.PowerPlatform.Dataverse.Client.Service"; // this is the base cache key name that will be used to cache the service. 
 
 		//OAuth Params
-		private string _clientId;                           // client id to register your application for OAuth
-		private Uri _redirectUri;                           // uri specifying the redirection uri post OAuth auth
 		private PromptBehavior _promptBehavior;             // prompt behavior
 		private string _tokenCachePath;                     // user specified token cache file path  
-		private string _resource;                           // Resource to connect to
 		private bool _isOnPremOAuth = false;                // Identifies whether the connection is for OnPrem or Online Deployment for OAuth
-		private static string _authority;                   //cached authority reading from credential manager
 		private static string _userId = null;               //cached userid reading from config file
 		private bool _isCalledbyExecuteRequest = false;     //Flag indicating that the an request called by Execute_Command
 		private bool _isDefaultCredsLoginForOAuth = false;  //Flag indicating that the user is trying to login with the current user id. 
@@ -119,6 +115,27 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		/// if Set to true then the connection is for one use and should be cleand out of cache when completed. 
 		/// </summary>
 		private bool unqueInstance = false;
+
+		/// <summary>
+        /// Client or App Id to use. 
+        /// </summary>
+		private string _clientId;
+
+		/// <summary>
+		/// uri specifying the redirection uri post OAuth auth
+		/// </summary>
+		private Uri _redirectUri;
+
+		/// <summary>
+		/// Resource to connect to
+		/// </summary>
+		private string _resource;
+
+		/// <summary>
+		/// cached authority reading from credential manager
+		/// </summary>
+		internal static string _authority;
+
 		/// <summary>
 		/// when certificate Auth is used,  this is the certificate that is used to execute the connection. 
 		/// </summary>
@@ -1370,6 +1387,12 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 			TenantId = sourceClient.TenantId;
 			EnvironmentId = sourceClient.EnvironmentId;
 			GetAccessTokenAsync = sourceClient.GetAccessToken;
+			_clientId = sourceClient._connectionSvc._clientId;
+			_certificateStoreLocation = sourceClient._connectionSvc._certificateStoreLocation;
+			_certificateThumbprint = sourceClient._connectionSvc._certificateThumbprint;
+			_certificateOfConnection = sourceClient._connectionSvc._certificateOfConnection;
+			_redirectUri = sourceClient._connectionSvc._redirectUri;
+			_resource = sourceClient._connectionSvc._resource; 
 		}
 
 		#region WebAPI Interface Utilities

--- a/src/GeneralTools/DataverseClient/Client/Interfaces/IOrganizationServiceAsync.cs
+++ b/src/GeneralTools/DataverseClient/Client/Interfaces/IOrganizationServiceAsync.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		/// <param name="entityName">Logical name of entity</param>
 		/// <param name="id">Id of entity</param>
 		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-		void DeleteAsync(string entityName, Guid id, CancellationToken cancellationToken);
+		Task DeleteAsync(string entityName, Guid id, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Perform an action in an organization specified by the request.
@@ -69,7 +69,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		/// <param name="relationship"></param>
 		/// <param name="relatedEntities"></param>
 		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-		void AssociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities, CancellationToken cancellationToken);
+		Task AssociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Disassociate an entity with a set of entities
@@ -79,7 +79,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		/// <param name="relationship"></param>
 		/// <param name="relatedEntities"></param>
 		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-		void DisassociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities, CancellationToken cancellationToken);
+		Task DisassociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Retrieves a collection of entities

--- a/src/GeneralTools/DataverseClient/Client/ServiceClient.cs
+++ b/src/GeneralTools/DataverseClient/Client/ServiceClient.cs
@@ -28,6 +28,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.PowerPlatform.Dataverse.Client.Auth;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using System.Threading;
+using System.Dynamic;
 
 namespace Microsoft.PowerPlatform.Dataverse.Client
 {
@@ -5033,11 +5034,13 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                     }
 
                     string bodyOfRequest = string.Empty;
-                    if (cReq.Attributes != null && cReq.Attributes.Count > 0)
-                    {
-                        var requestBodyObject = Utilities.ToExpandoObject(cReq.LogicalName, cReq.Attributes, _metadataUtlity);
+
+                    ExpandoObject requestBodyObject = Utilities.ToExpandoObject(cReq, _metadataUtlity);
+                    if (cReq.RelatedEntities != null && cReq.RelatedEntities.Count > 0)
+                        requestBodyObject = Utilities.ReleatedEntitiesToExpandoObject(requestBodyObject, cReq.LogicalName, cReq.RelatedEntities, _metadataUtlity);
+
+                    if (requestBodyObject != null)
                         bodyOfRequest = Newtonsoft.Json.JsonConvert.SerializeObject(requestBodyObject);
-                    }
 
                     // Process request params. 
                     if (req.Parameters.ContainsKey(Utilities.RequestHeaders.BYPASSCUSTOMPLUGINEXECUTION))
@@ -6561,7 +6564,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         /// <param name="relationship"></param>
         /// <param name="relatedEntities"></param>
         /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-        public async void AssociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities, CancellationToken cancellationToken)
+        public async Task AssociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities, CancellationToken cancellationToken)
         {
             AssociateResponse resp = (AssociateResponse)await ExecuteOrganizationRequestAsyncImpl(new AssociateRequest()
             {
@@ -6616,7 +6619,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         /// <param name="entityName">Logical name of entity</param>
         /// <param name="id">Id of entity</param>
         /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-        public async void DeleteAsync(string entityName, Guid id, CancellationToken cancellationToken = default)
+        public async Task DeleteAsync(string entityName, Guid id, CancellationToken cancellationToken = default)
         {
             DeleteResponse resp = (DeleteResponse)await ExecuteOrganizationRequestAsyncImpl(
                new DeleteRequest()
@@ -6638,7 +6641,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         /// <param name="relationship"></param>
         /// <param name="relatedEntities"></param>
         /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-        public async void DisassociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities, CancellationToken cancellationToken = default)
+        public async Task DisassociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities, CancellationToken cancellationToken = default)
         {
             DisassociateResponse resp = (DisassociateResponse) await ExecuteOrganizationRequestAsyncImpl(new DisassociateRequest()
             {

--- a/src/GeneralTools/DataverseClient/Client/TraceLoggerBase.cs
+++ b/src/GeneralTools/DataverseClient/Client/TraceLoggerBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		/// <summary>
 		/// String Builder Info
 		/// </summary>
-		private StringBuilder _lastError = new StringBuilder();
+		private string _lastError = string.Empty;
 
 		/// <summary>
 		/// string _traceSourceName private field
@@ -103,9 +103,10 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		/// <summary>
 		/// Last Error from CRM
 		/// </summary>
-		public StringBuilder LastError
+		public string LastError
 		{
 			get { return _lastError; }
+			set { _lastError = value; }
 		}
 		/// <summary>
 		/// Last Exception from CRM 

--- a/src/GeneralTools/DataverseClient/Client/Utils/DataverseOperationException.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/DataverseOperationException.cs
@@ -31,12 +31,13 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Utils
         /// <param name="errorCode">Error code</param>
         /// <param name="data">Data Properties</param>
         /// <param name="helpLink">Help Link</param>
-        public DataverseOperationException(string message, int errorCode , string helpLink , IDictionary<string,string> data)
-            : base(message)
+        /// <param name="httpOperationException"></param>
+        public DataverseOperationException(string message, int errorCode , string helpLink , IDictionary<string,string> data , HttpOperationException httpOperationException = null)
+            : base(message, httpOperationException)
         {
             HResult = errorCode;
             HelpLink = helpLink;
-            Source = "Cds Server API";
+            Source = "Dataverse Server API";
             foreach (var itm in data)
             {
                 this.Data.Add(itm.Key, itm.Value);
@@ -67,11 +68,10 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Utils
                         cdsErrorData.Add(node.Value<JProperty>().Name.ToString().Replace(errorDetailPrefixString, string.Empty), node.HasValues ? node.Value<JProperty>().Value.ToString() : string.Empty);
                     }
                 }
-                return new DataverseOperationException(errorMessage, HResult, HelpLink, cdsErrorData);
+                return new DataverseOperationException(errorMessage, HResult, HelpLink, cdsErrorData, httpOperationException);
             }
             else
-                return new DataverseOperationException("Server Error, no error report generated from server" , -1 , string.Empty, cdsErrorData);
-
+                return new DataverseOperationException("Server Error, no error report generated from server" , -1 , string.Empty, cdsErrorData, httpOperationException);
         }
 
         /// <summary>

--- a/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/DataverseClient_Core_UnitTests.csproj
+++ b/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/DataverseClient_Core_UnitTests.csproj
@@ -13,6 +13,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Cds.CoreAssemblies.Internal" Version="$(PackageVersion_CDSServerNuget)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="$(PackageVersion_Moq)" />
     <PackageReference Include="xunit" Version="$(PackageVersion_XUnit)" />

--- a/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/TestSupport.cs
+++ b/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/TestSupport.cs
@@ -147,6 +147,12 @@ namespace Client_Core_UnitTests
                 proInfo3.SetValue(entityMetadata, attribmetadata.ToArray(), null);
             }
 
+            System.Reflection.PropertyInfo proInfo4 = entityMetadata.GetType().GetProperty("PrimaryIdAttribute");
+            if (proInfo4 != null)
+            {
+                proInfo4.SetValue(entityMetadata, "accountid", null);
+            }
+
             RetrieveEntityResponse retrieveEntityResponse = new RetrieveEntityResponse();
             retrieveEntityResponse.Results.Add("EntityMetadata", entityMetadata);
 

--- a/src/nuspecs/Microsoft.Dynamics.Sdk.Messages.nuspec
+++ b/src/nuspecs/Microsoft.Dynamics.Sdk.Messages.nuspec
@@ -6,8 +6,9 @@
     <authors>Microsoft</authors>
     <owners>crmsdk,Microsoft</owners>
     <licenseUrl>https://go.microsoft.com/fwlink/?linkid=2108407</licenseUrl>
-    <projectUrl>https://github.com/microsoft/PowerPlatform-CdsServiceClient</projectUrl>
+    <projectUrl>https://github.com/microsoft/PowerPlatform-DataverseServiceClient</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <icon>images\Dataverse.128x128.png</icon>
     <description>This package contains the preview of the .net core Dynamics Messages Assembly. Used to issue commands to Dynamics Applications Installed on Microsoft Dataverse. This Package has been authored by the Microsoft Dataverse SDK team.</description>
     <summary>This package contains messages used to interact with the Dynamics CE applications via the Dataverse ServiceClient.</summary>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
@@ -49,5 +50,6 @@
     <file src="{signedBinDir}\{configuration}\DataverseClient\net472\Microsoft.Dynamics.Sdk.Messages.dll" target="lib\net472\Microsoft.Dynamics.Sdk.Messages.dll" />
     <file src="{signedBinDir}\{configuration}\DataverseClient\net462\Microsoft.Dynamics.Sdk.Messages.dll" target="lib\net462\Microsoft.Dynamics.Sdk.Messages.dll" />
     <file src="{signedBinDir}\{configuration}\DataverseClient\net48\Microsoft.Dynamics.Sdk.Messages.dll" target="lib\net48\Microsoft.Dynamics.Sdk.Messages.dll" />
+    <file src="{sharedImagesDir}\Desktop\Dataverse.128x128.png" target="images\Dataverse.128x128.png" />
   </files>
 </package>

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.Dynamics.nuspec
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.Dynamics.nuspec
@@ -6,7 +6,8 @@
     <authors>Microsoft</authors>
     <owners>crmsdk,Microsoft</owners>
     <licenseUrl>https://go.microsoft.com/fwlink/?linkid=2108407</licenseUrl>
-    <projectUrl>https://github.com/microsoft/PowerPlatform-CdsServiceClient</projectUrl>
+    <projectUrl>https://github.com/microsoft/PowerPlatform-DataverseServiceClient</projectUrl>
+    <icon>images\Dataverse.128x128.png</icon>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>This package contains the preview of the .net core ServiceClient Dynamics Extensions. Used to connect to Microsoft Dataverse. This Package has been authored by the Microsoft Dataverse SDK team.</description>
     <summary>ServiceClient and supporting libraries for use in building client applications to interact with the Dataverse</summary>
@@ -54,5 +55,6 @@
     <file src="{signedBinDir}\{configuration}\DataverseClient\net462\Microsoft.PowerPlatform.Dataverse.Client.Dynamics.xml" target="lib\net462\Microsoft.PowerPlatform.Dataverse.Client.Dynamics.xml" />
     <file src="{signedBinDir}\{configuration}\DataverseClient\net48\Microsoft.PowerPlatform.Dataverse.Client.Dynamics.dll" target="lib\net48\Microsoft.PowerPlatform.Dataverse.Client.Dynamics.dll" />
     <file src="{signedBinDir}\{configuration}\DataverseClient\net48\Microsoft.PowerPlatform.Dataverse.Client.Dynamics.xml" target="lib\net48\Microsoft.PowerPlatform.Dataverse.Client.Dynamics.xml" />
+    <file src="{sharedImagesDir}\Desktop\Dataverse.128x128.png" target="images\Dataverse.128x128.png" />
   </files>
 </package>

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
@@ -8,6 +8,15 @@ Notice:
         https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/xrm-tooling/use-connection-strings-xrm-tooling-connect
     Note: that only OAuth, Certificate, ClientSecret Authentication types are supported at this time. 
 
+++CURRENTRELEASEID++
+Added support for related entity create as part of general "create" operation. 
+Updated Async Operations to return task's for async methods that were returning void's
+Updated DataverseOperationException to include HttpOperationResponse, where it exists.
+Fixed issue with Cloned Connections not refreshing their tokens on token expiration 
+Updated Logger to remove string builder property
+Added Initial code for ILogger implementation. (Not exposed as of yet but coming soon) 
+Corrected an issue when using the Entity myEnt = new Entity(string, guid) not properly setting the primary id. 
+
 0.4.1:
 Supersedes Microsoft.PowerPlatform.Cds.Client,  Previous nuget has been retired. 
 ***** MAJOR Breaking Changes *****

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.nuspec
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.nuspec
@@ -6,7 +6,8 @@
     <authors>Microsoft</authors>
     <owners>crmsdk,Microsoft</owners>
     <licenseUrl>https://go.microsoft.com/fwlink/?linkid=2108407</licenseUrl>
-    <projectUrl>https://github.com/microsoft/PowerPlatform-CdsServiceClient</projectUrl>
+    <projectUrl>https://github.com/microsoft/PowerPlatform-DataverseServiceClient</projectUrl>
+    <icon>images\Dataverse.128x128.png</icon>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>This package contains the preview of the .net core Dataverse ServiceClient. Used to connect to Microsoft Dataverse. This Package has been authored by the Microsoft Dataverse SDK team.</description>
     <summary>CdsServiceClient and supporting libraries for use in building client applications to interact with the Dataverse</summary>
@@ -130,5 +131,6 @@
     <file src="{signedBinDir}\{configuration}\DataverseClient\net462\Microsoft.Cds.Sdk.Proxy.dll" target="lib\net462\Microsoft.Cds.Sdk.Proxy.dll" />
     <file src="{licenseDir}\Other Redistributable.txt" target="lib\net462\Other Redistributable.txt" />
     <file src="{licenseDir}\Third Party Notices for Dynamics 365 SDK.docx" target="lib\net462\Third Party Notices for Dynamics 365 SDK.docx" />
+    <file src="{sharedImagesDir}\Desktop\Dataverse.128x128.png" target="images\Dataverse.128x128.png" />
   </files>
 </package>


### PR DESCRIPTION
**Addressing a number of things with this update:**

Added support for related entity create as part of general "create" operation.
Updated Async Operations to return task's for async methods that were returning void's
Updated DataverseOperationException to include HttpOperationResponse, where it exists.
Fixed issue with Cloned Connections not refreshing their tokens on token expiration
Updated Logger to remove string builder property
Added Initial code for ILogger implementation. (Not exposed as of yet but coming soon)
Corrected an issue when using the Entity myEnt = new Entity(string, guid) not properly setting the primary id.
