### PR TITLE
Read the SDK version from the AssemblyFileVersion attribute

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/ServiceClient.cs
+++ b/src/GeneralTools/DataverseClient/Client/ServiceClient.cs
@@ -29,6 +29,7 @@ using Microsoft.PowerPlatform.Dataverse.Client.Auth;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using System.Threading;
 using System.Dynamic;
+using System.Reflection;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.PowerPlatform.Dataverse.Client
@@ -549,7 +550,8 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             {
                 if (string.IsNullOrEmpty(_sdkVersionProperty))
                 {
-                    _sdkVersionProperty = FileVersionInfo.GetVersionInfo(typeof(OrganizationWebProxyClient).Assembly.Location).FileVersion;
+                    var assembly = typeof(OrganizationWebProxyClient).Assembly;
+                    _sdkVersionProperty = assembly.GetCustomAttribute<AssemblyFileVersion>()?.Value ?? FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion;
                 }
                 return _sdkVersionProperty;
             }


### PR DESCRIPTION
Fallback to reading the version from the on-disk assembly if not available from the AssemblyFileVersion attribute.

This is useful for scenarios where the assembly is not loaded from disk such as when packaging an app with [Costura](https://github.com/Fody/Costura/)