### PR TITLE
Sync update for Nuget Release 0.4.19

### DIFF
--- a/src/Build.Common.StandardAndLegacy.props
+++ b/src/Build.Common.StandardAndLegacy.props
@@ -4,8 +4,8 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(TargetFrameworks)' == ''">
-    <TargetFrameworks Condition="'$(OutputType)' == 'Exe'">netcoreapp3.1;net462</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OutputType)' != 'Exe'">netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OutputType)' == 'Exe'">net5.0;net48;net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OutputType)' != 'Exe'">netstandard2.0;net48;net462</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/Build.Shared.props
+++ b/src/Build.Shared.props
@@ -7,10 +7,10 @@
     <PackageVersion_MSAL>4.25.0</PackageVersion_MSAL>
     <PackageVersion_CdsSdk>4.6.3291-weekly-2104.2</PackageVersion_CdsSdk>
     <PackageVersion_CDSServerNuget>4.6.3291-weekly-2104.2</PackageVersion_CDSServerNuget>
-    <PackageVersion_Newtonsoft>10.0.3</PackageVersion_Newtonsoft>
+    <PackageVersion_Newtonsoft>11.0.2</PackageVersion_Newtonsoft>
     <PackageVersion_RestClientRuntime>2.3.20</PackageVersion_RestClientRuntime>
     <PackageVersion_XrmSdk>9.0.2.25</PackageVersion_XrmSdk>
-    <PackageVersion_BatchedTelemetry>2.0.5</PackageVersion_BatchedTelemetry>
+    <PackageVersion_BatchedTelemetry>2.0.11</PackageVersion_BatchedTelemetry>
     <!-- Test: -->
     <PackageVersion_Moq>4.16.0</PackageVersion_Moq>
     <PackageVersion_XUnit>2.4.1</PackageVersion_XUnit>

--- a/src/GeneralTools/DataverseClient/Client/Utils/Utils.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/Utils.cs
@@ -383,8 +383,14 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                 }
                 else
                 {
-                    if (value is EntityCollection)
+                    if (value is EntityCollection || value is Entity[])
                     {
+                        if ( value is Entity[] v1s)
+                        {
+                            EntityCollection ec = new EntityCollection(((Entity[])value).ToList<Entity>());
+                            value = ec;
+                        }
+
                         // try to get the participation type id from the key.
                         int PartyTypeId = PartyListHelper.GetParticipationtypeMasks(key);
                         bool isActivityParty = PartyTypeId != -1;  // if the partytypeID is -1 this is not a activity party collection.
@@ -399,7 +405,8 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                             if (isActivityParty)
                             {
                                 var tempDict = ((IDictionary<string, object>)rslt);
-                                tempDict.Add("participationtypemask", PartyTypeId);
+                                if (!tempDict.ContainsKey("participationtypemask"))
+                                    tempDict.Add("participationtypemask", PartyTypeId);
                                 partiesCollection.Add((ExpandoObject)tempDict);
                             }
                         }
@@ -818,6 +825,12 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             /// Minimum version support for Solution tagging.
             /// </summary>
             internal static Version AllowTemplateSolutionImport = new Version("9.2.21013.00131");
+
+            /// <summary>
+            /// Minimum version support for ImportSolutionAsync API.
+            /// </summary>
+            internal static Version AllowImportSolutionAsyncV2 = new Version("9.2.21013.00131");
+
 
         }
 

--- a/src/nuspecs/Microsoft.Dynamics.Sdk.Messages.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.Dynamics.Sdk.Messages.ReleaseNotes.txt
@@ -6,6 +6,9 @@ Notice:
         https://docs.microsoft.com/en-us/dotnet/api/microsoft.crm.sdk.messages?view=dynamics-general-ce-9
 
 ++CURRENTRELEASEID++
+    Updated Newtonsoft.Json to v11.0.2 to match server.
+
+0.4.12:
     Updated Dataverse Messages
 
 0.4.11:

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.Dynamics.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.Dynamics.ReleaseNotes.txt
@@ -3,6 +3,9 @@ Notice:
     This package is intended to work with .net full framework 4.6.2, 4.7.2 and 4.8, .net core 3.0 and 3.1 
 
 ++CURRENTRELEASEID++
+    Updated Newtonsoft.Json to v11.0.2 to match server.
+
+0.4.12:
     Updated Dataverse Messages
 
 0.4.11:

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
@@ -8,6 +8,12 @@ Notice:
     Note: that only OAuth, Certificate, ClientSecret Authentication types are supported at this time.
 
 ++CURRENTRELEASEID++
+Updated behavior of ImportSolutionAsync to leverage updated Dataverse behavior post 9.2 release.
+Updated Display name for Northamerica 2 Region to reflect that it is more commonly know as GCC. 
+Updated Newtonsoft.Json to v11.0.2 to match server.
+Fixed an issue with ActivityParty when using an Entity Array vs an EntityCollection for ActivityParties 
+
+0.4.12:
 Fixed an issue raised when updating some entities\attributes values to null.
 Fixed and issue with DataTime formatting for Timezone independent, Timezone specific, and 'normal' DateTime types. 
 Update for Current Dataverse System Messages.

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.nuspec
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.nuspec
@@ -20,7 +20,7 @@
         <dependency id="Microsoft.Extensions.Logging" version="3.1.8" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Identity.Client" version="4.25.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="11.0.2" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETFramework4.7.2">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="3.1.8" exclude="Build,Analyzers" />
@@ -28,7 +28,7 @@
         <dependency id="Microsoft.Extensions.Logging" version="3.1.8" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Identity.Client" version="4.25.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="11.0.2" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETFramework4.8">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="3.1.8" exclude="Build,Analyzers" />
@@ -36,7 +36,7 @@
         <dependency id="Microsoft.Extensions.Logging" version="3.1.8" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Identity.Client" version="4.25.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="11.0.2" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETCoreApp3.0">
         <dependency id="System.Collections" version="4.3.0" exclude="Build,Analyzers" />
@@ -59,7 +59,7 @@
         <dependency id="Microsoft.Identity.Client" version="4.25.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
         <dependency id="Microsoft.VisualBasic" version="10.3.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="11.0.2" exclude="Build,Analyzers" />
         <dependency id="System.Configuration.ConfigurationManager" version="4.7.0" exclude="Build,Analyzers" />
         <dependency id="System.Runtime.Caching" version="4.7.0" exclude="Build,Analyzers" />
         <dependency id="System.Security.Cryptography.Algorithms" version="4.3.1" exclude="Build,Analyzers" />
@@ -86,7 +86,7 @@
         <dependency id="Microsoft.Identity.Client" version="4.25.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
         <dependency id="Microsoft.VisualBasic" version="10.3.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="11.0.2" exclude="Build,Analyzers" />
         <dependency id="System.Configuration.ConfigurationManager" version="4.7.0" exclude="Build,Analyzers" />
         <dependency id="System.Runtime.Caching" version="4.7.0" exclude="Build,Analyzers" />
         <dependency id="System.Security.Cryptography.Algorithms" version="4.3.1" exclude="Build,Analyzers" />


### PR DESCRIPTION
https://www.nuget.org/packages/Microsoft.PowerPlatform.Dataverse.Client/0.4.19

Updated behavior of ImportSolutionAsync to leverage updated Dataverse behavior post 9.2 release.
Updated Display name for Northamerica 2 Region to reflect that it is more commonly know as GCC. 
Updated Newtonsoft.Json to v11.0.2 to match server.
Fixed #136 an issue with ActivityParty when using an Entity Array vs an EntityCollection for ActivityParties
Fixed #137 Bad error parse exception when no data is returned to the exception handler. 