### PR TITLE
Sync up from Mainline branch for CommitId 25d429b36d15aab25cf647d6033…

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/Auth/AuthProcessor.cs
+++ b/src/GeneralTools/DataverseClient/Client/Auth/AuthProcessor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
     internal class AuthProcessor
     {
 		/// <summary>
-		/// Executes Authentication against a service 
+		/// Executes Authentication against a service
 		/// </summary>
 		/// <param name="serviceUrl"></param>
 		/// <param name="clientCredentials"></param>
@@ -35,38 +35,38 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 		/// <param name="addVersionInfoToUri">indicates if the serviceURI should be updated to include the /web?sdk version</param>
 		/// <returns>AuthenticationResult containing a JWT Token for the requested Resource and user/app</returns>
 		internal async static Task<ExecuteAuthenticationResults> ExecuteAuthenticateServiceProcessAsync(
-			Uri serviceUrl, 
-			ClientCredentials clientCredentials, 
-			X509Certificate2 userCert, 
-			string clientId, 
-			Uri redirectUri, 
-			PromptBehavior promptBehavior, 
-			bool isOnPrem, 
-			string authority, 
-			object msalAuthClient , 
-			DataverseTraceLogger logSink = null, 
-			bool useDefaultCreds = false, 
-			SecureString clientSecret = null, 
+			Uri serviceUrl,
+			ClientCredentials clientCredentials,
+			X509Certificate2 userCert,
+			string clientId,
+			Uri redirectUri,
+			PromptBehavior promptBehavior,
+			bool isOnPrem,
+			string authority,
+			object msalAuthClient ,
+			DataverseTraceLogger logSink = null,
+			bool useDefaultCreds = false,
+			SecureString clientSecret = null,
 			bool addVersionInfoToUri = true,
 			IAccount user = null
 			)
 		{
 			ExecuteAuthenticationResults processResult = new ExecuteAuthenticationResults();
 			bool createdLogSource = false;
-			
+
 			AuthenticationResult authenticationResult = null;
 
 			try
 			{
 				if (logSink == null)
 				{
-					// when set, the log source is locally created. 
+					// when set, the log source is locally created.
 					createdLogSource = true;
 					logSink = new DataverseTraceLogger();
 				}
 
 				string Authority = string.Empty;
-				string Resource = string.Empty; 
+				string Resource = string.Empty;
 
 				bool clientCredentialsCheck = clientCredentials != null && clientCredentials.UserName != null && !string.IsNullOrEmpty(clientCredentials.UserName.UserName) && !string.IsNullOrEmpty(clientCredentials.UserName.Password);
 				Resource = serviceUrl.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped);
@@ -96,21 +96,21 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 				}
 				//	clientCredentialsCheck = false;  // Forcing system to provide a UX popup vs UID/PW
 
-				// Assign outbound properties. 
+				// Assign outbound properties.
 				processResult.Resource = Resource;
-				processResult.Authority = Authority; 
+				processResult.Authority = Authority;
 
 				logSink.Log("AuthenticateService - found authority with name " + (string.IsNullOrEmpty(Authority) ? "<Not Provided>" : Authority));
 				logSink.Log("AuthenticateService - found resource with name " + (string.IsNullOrEmpty(Resource) ? "<Not Provided>" : Resource));
 
 				Uri ResourceUri = new Uri(Resource);
-                // Add Scope, 
+                // Add Scope,
                 List<string> Scopes = Utilities.AddScope($"{Resource}/user_impersonation");
 
 				AuthenticationResult _authenticationResult = null;
 				if (userCert != null || clientSecret != null)
 				{
-					// Add Scope, 
+					// Add Scope,
 					Scopes.Clear();
 					Scopes = Utilities.AddScope($"{Resource}.default" , Scopes);
 
@@ -138,7 +138,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 					{
 						logSink.Log("Initial ObtainAccessToken - CERT", TraceEventType.Verbose);
 						cApp = cAppBuilder.WithCertificate(userCert).Build();
-						_authenticationResult = await ObtainAccessTokenAsync(cApp, Scopes, logSink);
+						_authenticationResult = await ObtainAccessTokenAsync(cApp, Scopes, logSink).ConfigureAwait(false);
 					}
 					else
 					{
@@ -146,19 +146,19 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 						{
 							logSink.Log("Initial ObtainAccessToken - Client Secret", TraceEventType.Verbose);
 							cApp = cAppBuilder.WithClientSecret(clientSecret.ToUnsecureString()).Build();
-							_authenticationResult = await ObtainAccessTokenAsync(cApp, Scopes, logSink);
+							_authenticationResult = await ObtainAccessTokenAsync(cApp, Scopes, logSink).ConfigureAwait(false);
 						}
 						else
 							throw new Exception("Invalid Cert or Client Secret Auth flow");
 					}
 
 					// Update the MSAL Client handed back.
-					processResult.MsalAuthClient = cApp; 
+					processResult.MsalAuthClient = cApp;
 				}
 				else
 				{
 					PublicClientApplicationBuilder cApp = null;
-					IPublicClientApplication pApp = null; 
+					IPublicClientApplication pApp = null;
 					if (msalAuthClient is IPublicClientApplication)
 					{
 						pApp = (IPublicClientApplication)msalAuthClient;
@@ -179,8 +179,8 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 						pApp = cApp.Build();
 					}
 
-					//Run user Auth flow. 
-					_authenticationResult = await ObtainAccessTokenAsync(pApp, Scopes, user, promptBehavior, clientCredentials, useDefaultCreds, logSink);
+					//Run user Auth flow.
+					_authenticationResult = await ObtainAccessTokenAsync(pApp, Scopes, user, promptBehavior, clientCredentials, useDefaultCreds, logSink).ConfigureAwait(false);
 
 					// Assign the application back out
 					processResult.MsalAuthClient = pApp;
@@ -195,7 +195,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 					//_userId = _authenticationResult.Account;
 					processResult.UserIdent = _authenticationResult.Account;
 				}
-		
+
 				if (null == _authenticationResult)
 				{
 					throw new ArgumentNullException("AuthenticationResult");
@@ -207,7 +207,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 			{
 				if (ex.InnerException is Microsoft.Identity.Client.MsalException)
 				{
-					var errorHandledResult = await ProcessAdalExecptionAsync(serviceUrl, clientCredentials, userCert, clientId, redirectUri, promptBehavior, isOnPrem, authority , msalAuthClient, logSink, useDefaultCreds , (Microsoft.Identity.Client.MsalException)ex.InnerException);
+					var errorHandledResult = await ProcessAdalExecptionAsync(serviceUrl, clientCredentials, userCert, clientId, redirectUri, promptBehavior, isOnPrem, authority , msalAuthClient, logSink, useDefaultCreds , (Microsoft.Identity.Client.MsalException)ex.InnerException).ConfigureAwait(false);
 					if (errorHandledResult != null)
 						processResult = errorHandledResult;
 				}
@@ -232,7 +232,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 			}
 			finally
 			{
-				if (createdLogSource) // Only dispose it if it was created locally. 
+				if (createdLogSource) // Only dispose it if it was created locally.
 					logSink.Dispose();
 			}
 			return processResult;
@@ -241,7 +241,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 
 
 		/// <summary>
-		///  Token refresh flow for MSAL User Flows. 
+		///  Token refresh flow for MSAL User Flows.
 		/// </summary>
 		/// <param name="publicAppClient">MSAL Client to use.</param>
 		/// <param name="scopes">Scopes to send in.</param>
@@ -260,10 +260,10 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 			bool useDefaultCreds = false,
 			DataverseTraceLogger logSink = null)
 		{
-			// This works for user Auth flows. 
+			// This works for user Auth flows.
 			AuthenticationResult _authenticationResult = null;
 			bool clientCredentialsCheck = clientCredentials != null && clientCredentials.UserName != null && !string.IsNullOrEmpty(clientCredentials.UserName.UserName) && !string.IsNullOrEmpty(clientCredentials.UserName.Password);
-			// Login user hint 
+			// Login user hint
 			string loginUserHint = (clientCredentials != null && clientCredentials.UserName != null) ? clientCredentials.UserName.UserName : string.Empty;
 			if (publicAppClient != null)
 			{
@@ -284,11 +284,11 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 					{
 						if (!string.IsNullOrEmpty(loginUserHint))
 						{
-							_authenticationResult = await publicAppClient.AcquireTokenByIntegratedWindowsAuth(scopes).WithUsername(loginUserHint).ExecuteAsync();
+							_authenticationResult = await publicAppClient.AcquireTokenByIntegratedWindowsAuth(scopes).WithUsername(loginUserHint).ExecuteAsync().ConfigureAwait(false);
 						}
 						else
 						{
-							_authenticationResult = await publicAppClient.AcquireTokenByIntegratedWindowsAuth(scopes).ExecuteAsync();
+							_authenticationResult = await publicAppClient.AcquireTokenByIntegratedWindowsAuth(scopes).ExecuteAsync().ConfigureAwait(false);
 						}
 					}
 					else
@@ -315,17 +315,17 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 
 						if (userPrompt != null)
 						{
-							_authenticationResult = await publicAppClient.AcquireTokenInteractive(scopes).WithLoginHint(loginUserHint).WithPrompt(userPrompt.Value).ExecuteAsync();
+							_authenticationResult = await publicAppClient.AcquireTokenInteractive(scopes).WithLoginHint(loginUserHint).WithPrompt(userPrompt.Value).ExecuteAsync().ConfigureAwait(false);
 						}
 						else
 						{
 							if (account != null)
 							{
-								_authenticationResult = await publicAppClient.AcquireTokenSilent(scopes, account).ExecuteAsync();
+								_authenticationResult = await publicAppClient.AcquireTokenSilent(scopes, account).ExecuteAsync().ConfigureAwait(false);
 							}
 							else
 							{
-								_authenticationResult = await publicAppClient.AcquireTokenInteractive(scopes).WithLoginHint(loginUserHint).ExecuteAsync();
+								_authenticationResult = await publicAppClient.AcquireTokenInteractive(scopes).WithLoginHint(loginUserHint).ExecuteAsync().ConfigureAwait(false);
 							}
 						}
 					}
@@ -333,14 +333,14 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 			}
 			else
 			{
-				// throw here. 
+				// throw here.
 			}
 			return _authenticationResult;
 		}
 
 
 		/// <summary>
-		/// Acquires Confidential client token. 
+		/// Acquires Confidential client token.
 		/// </summary>
 		/// <param name="confidentialAppClient">Confidential client application</param>
 		/// <param name="scopes">Scope List</param>
@@ -351,15 +351,15 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 			List<string> scopes,
 			DataverseTraceLogger logSink = null)
 		{
-			// This works for user Auth flows. 
+			// This works for user Auth flows.
 			AuthenticationResult _authenticationResult = null;
 			if (confidentialAppClient != null)
 			{
-				_authenticationResult = await confidentialAppClient.AcquireTokenForClient(scopes).ExecuteAsync();
+				_authenticationResult = await confidentialAppClient.AcquireTokenForClient(scopes).ExecuteAsync().ConfigureAwait(false);
 			}
 			else
 			{
-				// throw here. 
+				// throw here.
 			}
 			return _authenticationResult;
 		}
@@ -412,7 +412,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
         }
 
 		/// <summary>
-		/// Get authority and resource for this instance. 
+		/// Get authority and resource for this instance.
 		/// </summary>
 		/// <param name="targetServiceUrl">URI to query</param>
 		/// <param name="logger">Logger to write info too</param>
@@ -423,12 +423,12 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 			AuthRoutingProperties authRoutingProperties = new AuthRoutingProperties();
 			var client = clientFactory.CreateClient("DataverseHttpClientFactory");
 			var rslt = await client.GetAsync(targetServiceUrl).ConfigureAwait(false);
-			
+
 			if ( rslt.StatusCode == System.Net.HttpStatusCode.NotFound || rslt.StatusCode == System.Net.HttpStatusCode.BadRequest )
 			{
-				// didnt find endpoint. 
+				// didnt find endpoint.
 				logger.Log($"Failed to get Authority and Resource error. Attempt to Access Endpoint {targetServiceUrl.ToString()} resulted in {rslt.StatusCode}.", TraceEventType.Error);
-				return authRoutingProperties; 
+				return authRoutingProperties;
 			}
 
 			if (rslt.Headers.Contains("WWW-Authenticate"))
@@ -469,19 +469,19 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 				{
 					string param;
 					authenticateHeaderItems.TryGetValue(AuthorityKey, out param);
-					authRoutingProperties.Authority = 
+					authRoutingProperties.Authority =
 						param.Replace("oauth2/authorize", "") // swap out the old oAuth pattern.
-						.Replace("common" , "organizations"); // swap common for organizations because MSAL reasons. 
+						.Replace("common" , "organizations"); // swap common for organizations because MSAL reasons.
 					authenticateHeaderItems.TryGetValue(ResourceKey, out param);
 					authRoutingProperties.Resource = param;
 				}
 			}
 
-			return authRoutingProperties; 
+			return authRoutingProperties;
 		}
 
 		/// <summary>
-		/// Process ADAL exception and provide common handlers. 
+		/// Process ADAL exception and provide common handlers.
 		/// </summary>
 		/// <param name="serviceUrl"></param>
 		/// <param name="clientCredentials"></param>
@@ -499,7 +499,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 		{
 			if (adalEx.ErrorCode.Equals("interaction_required", StringComparison.OrdinalIgnoreCase) ||
 				adalEx.ErrorCode.Equals("user_password_expired", StringComparison.OrdinalIgnoreCase) ||
-				adalEx.ErrorCode.Equals("password_required_for_managed_user", StringComparison.OrdinalIgnoreCase) || 
+				adalEx.ErrorCode.Equals("password_required_for_managed_user", StringComparison.OrdinalIgnoreCase) ||
 				adalEx is Microsoft.Identity.Client.MsalUiRequiredException)
 			{
 				logSink.Log("ERROR REQUESTING TOKEN FROM THE AUTHENTICATION CONTEXT - USER intervention required", TraceEventType.Warning);
@@ -507,10 +507,10 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
 				if (promptBehavior == PromptBehavior.Always || promptBehavior == PromptBehavior.Auto)
 				{
 					// Switch to MFA user mode..
-					Microsoft.Identity.Client.IAccount user = null;  //TODO:UPDATE THIS OR REMOVE AS WE DETERMIN HOW TO SOLVE THIS ISSUE IN MSAL //  new Microsoft.Identity.Client.AccountId(); 
+					Microsoft.Identity.Client.IAccount user = null;  //TODO:UPDATE THIS OR REMOVE AS WE DETERMIN HOW TO SOLVE THIS ISSUE IN MSAL //  new Microsoft.Identity.Client.AccountId();
 					user = null;
 					//user = new UserIdentifier(clientCredentials.UserName.UserName, UserIdentifierType.OptionalDisplayableId);
-					return await ExecuteAuthenticateServiceProcessAsync(serviceUrl, null, userCert, clientId, redirectUri, promptBehavior, isOnPrem, authority, msalAuthClient, logSink, useDefaultCreds: useDefaultCreds, user: user);
+					return await ExecuteAuthenticateServiceProcessAsync(serviceUrl, null, userCert, clientId, redirectUri, promptBehavior, isOnPrem, authority, msalAuthClient, logSink, useDefaultCreds: useDefaultCreds, user: user).ConfigureAwait(false);
 				}
 				else
 				{

--- a/src/GeneralTools/DataverseClient/Client/DataverseTelemetryBehaviors.cs
+++ b/src/GeneralTools/DataverseClient/Client/DataverseTelemetryBehaviors.cs
@@ -11,7 +11,7 @@ using System.Xml;
 namespace Microsoft.PowerPlatform.Dataverse.Client
 {
     /// <summary>
-    /// Adding support to Send the User Agent Header. 
+    /// Adding support to Send the User Agent Header.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses")]
     internal class DataverseTelemetryBehaviors : IEndpointBehavior, IClientMessageInspector
@@ -29,14 +29,14 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         #endregion
 
         /// <summary>
-        /// Constructor for building the hook to call into the platform. 
+        /// Constructor for building the hook to call into the platform.
         /// </summary>
         public DataverseTelemetryBehaviors(ConnectionService cli)
         {
             _callerCdsConnectionServiceHandler = cli;
 
             // reading overrides from app config if present..
-            // these values override the values that are set on the client from the server. 
+            // these values override the values that are set on the client from the server.
             DataverseTraceLogger logg = new DataverseTraceLogger();
             try
             {
@@ -47,7 +47,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                     _userAgent = AppDomain.CurrentDomain.FriendlyName;
                 }
 
-                _userAgent = $"{_userAgent} (CdsSvcClient:{Environs.FileVersion})";
+                _userAgent = $"{_userAgent} (DataverseSvcClient:{Environs.FileVersion})";
 
                 if (_maxFaultSize == -1 && ConfigurationManager.AppSettings.AllKeys.Contains("MaxFaultSizeOverride"))
                 {
@@ -110,7 +110,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             clientRuntime.ClientMessageInspectors.Add(this);
 #endif
 
-            // when Set, this will ask WCF to transit cookies. 
+            // when Set, this will ask WCF to transit cookies.
             if (_callerCdsConnectionServiceHandler.EnableCookieRelay)
             {
                 if (endpoint.Binding is BasicHttpBinding)
@@ -118,7 +118,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                     ((BasicHttpBinding)endpoint.Binding).AllowCookies = true;
                 }
             }
-            // Override the Max Fault size if required. 
+            // Override the Max Fault size if required.
             if (_maxFaultSize != -1)
             {
                 clientRuntime.MaxFaultSize = _maxFaultSize;
@@ -130,7 +130,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                 clientRuntime.MaxFaultSize = 4 * 1024 * 1024;
             }
 
-            // Override the max received size if required. 
+            // Override the max received size if required.
             if (_maxReceivedMessageSize != -1)
             {
                 if (endpoint.Binding is BasicHttpBinding)
@@ -158,14 +158,14 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
         public object BeforeSendRequest(ref Message request, IClientChannel channel)
         {
-            // Try to get Request ID from inbound request. 
+            // Try to get Request ID from inbound request.
             Guid OrganizationRequestId = Guid.Empty;
             try
             {
-                // Get a copy to work with. 
+                // Get a copy to work with.
                 using (MessageBuffer mbuff = request.CreateBufferedCopy(Int32.MaxValue))
                 {
-                    request = mbuff.CreateMessage();  // Copy it back to the request buffer. 
+                    request = mbuff.CreateMessage();  // Copy it back to the request buffer.
                     using (XmlDictionaryReader msgReader = mbuff.CreateMessage().GetReaderAtBodyContents())
                     {
                         msgReader.MoveToContent();
@@ -175,7 +175,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                             {
                                 string readValue = msgReader.ReadElementContentAsString();
                                 if (!string.IsNullOrEmpty(readValue))
-                                    Guid.TryParse(readValue, out OrganizationRequestId); // Find the request ID from the message and assign it to the new tracking id. 
+                                    Guid.TryParse(readValue, out OrganizationRequestId); // Find the request ID from the message and assign it to the new tracking id.
                                 break;
                             }
                         }
@@ -243,12 +243,12 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                     callerId = _callerCdsConnectionServiceHandler.WebClient.CallerId;
             }
 
-            if (callerId == Guid.Empty) // Prefer the CRM Caller ID over hte AADObjectID. 
+            if (callerId == Guid.Empty) // Prefer the CRM Caller ID over hte AADObjectID.
             {
                 if (_callerCdsConnectionServiceHandler != null && (_callerCdsConnectionServiceHandler.CallerAADObjectId.HasValue && _callerCdsConnectionServiceHandler.CallerAADObjectId.Value != Guid.Empty))
                 {
-                    // Add Caller ID to the SOAP Envolope. 
-                    // Set a header request with the AAD Caller Object ID. 
+                    // Add Caller ID to the SOAP Envolope.
+                    // Set a header request with the AAD Caller Object ID.
                     using (OperationContextScope scope = new OperationContextScope((IContextChannel)channel))
                     {
                         var AADCallerIdHeader = new MessageHeader<Guid>(_callerCdsConnectionServiceHandler.CallerAADObjectId.Value).GetUntypedHeader(Utilities.RequestHeaders.AAD_CALLER_OBJECT_ID_HTTP_HEADER, "http://schemas.microsoft.com/xrm/2011/Contracts");

--- a/src/GeneralTools/DataverseClient/Client/DataverseTraceLogger.cs
+++ b/src/GeneralTools/DataverseClient/Client/DataverseTraceLogger.cs
@@ -7,7 +7,7 @@ using System.ServiceModel;
 using Microsoft.Xrm.Sdk;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
-using System.Linq; 
+using System.Linq;
 using Microsoft.Rest;
 using Newtonsoft.Json.Linq;
 using Microsoft.PowerPlatform.Dataverse.Client.Utils;
@@ -21,10 +21,10 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 	[LocalizableAttribute(false)]
 	internal sealed class DataverseTraceLogger : TraceLoggerBase
 	{
-		// Internal connection of exceptions since last clear. 
+		// Internal connection of exceptions since last clear.
 		private List<Exception> _ActiveExceptionsList;
 
-		private ILogger _logger; 
+		private ILogger _logger;
 
 		#region Properties
 		/// <summary>
@@ -36,7 +36,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		}
 
 		/// <summary>
-		/// Default TraceSource Name 
+		/// Default TraceSource Name
 		/// </summary>
 		public string DefaultTraceSourceName
 		{
@@ -44,7 +44,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		}
 
 		/// <summary>
-		/// Collection of logs captured to date. 
+		/// Collection of logs captured to date.
 		/// </summary>
 		public ConcurrentQueue<Tuple<DateTime, string>> Logs { get; private set; } = new ConcurrentQueue<Tuple<DateTime, string>>();
 
@@ -54,8 +54,8 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		public TimeSpan LogRetentionDuration { get; set; } = TimeSpan.FromMinutes(5);
 
 		/// <summary>
-		/// Enables or disabled in-memory log capture. 
-		/// Default is false. 
+		/// Enables or disabled in-memory log capture.
+		/// Default is false.
 		/// </summary>
 		public bool EnabledInMemoryLogCapture { get; set; } = false;
 
@@ -64,7 +64,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		#region Public Methods
 
 		/// <summary>
-		/// Constructs the CdsTraceLogger class. 
+		/// Constructs the CdsTraceLogger class.
 		/// </summary>
 		/// <param name="traceSourceName"></param>
 		public DataverseTraceLogger(string traceSourceName = "")
@@ -79,7 +79,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 				TraceSourceName = traceSourceName;
 			}
 
-			_ActiveExceptionsList = new List<Exception>(); 
+			_ActiveExceptionsList = new List<Exception>();
 
 			base.Initialize();
 		}
@@ -98,7 +98,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 			if (base.LastError.Length > 0 )
 				base.LastError.Remove(0, LastError.Length -1 );
 			LastException = null;
-			_ActiveExceptionsList.Clear(); 
+			_ActiveExceptionsList.Clear();
 		}
 
 		/// <summary>
@@ -113,7 +113,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		}
 
 		/// <summary>
-		/// Log a Message 
+		/// Log a Message
 		/// </summary>
 		/// <param name="message"></param>
 		public override void Log(string message)
@@ -122,7 +122,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		}
 
 		/// <summary>
-		/// Log a Trace event 
+		/// Log a Trace event
 		/// </summary>
 		/// <param name="message"></param>
 		/// <param name="eventType"></param>
@@ -139,7 +139,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		}
 
 		/// <summary>
-		/// Log a Trace event 
+		/// Log a Trace event
 		/// </summary>
 		/// <param name="message"></param>
 		/// <param name="eventType"></param>
@@ -150,23 +150,23 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 			{
 				exception = new Exception(message);
 			}
-			
+
 			StringBuilder detailedDump = new StringBuilder();
 			StringBuilder lastMessage = new StringBuilder();
 
-			lastMessage.AppendLine(message); // Added to fix missing last error line. 
-			detailedDump.AppendLine(message); // Added to fix missing error line. 
+			lastMessage.AppendLine(message); // Added to fix missing last error line.
+			detailedDump.AppendLine(message); // Added to fix missing error line.
 
-			if (!(exception != null && _ActiveExceptionsList.Contains(exception))) // Skip this line if its already been done. 
+			if (!(exception != null && _ActiveExceptionsList.Contains(exception))) // Skip this line if its already been done.
 				GetExceptionDetail(exception, detailedDump, 0, lastMessage);
 
 			TraceEvent(eventType, (int)eventType, detailedDump.ToString(), exception);
 			if (eventType == TraceEventType.Error)
 			{
 				base.LastError += lastMessage.ToString();
-				if (!(exception != null && _ActiveExceptionsList.Contains(exception))) // Skip this line if its already been done. 
+				if (!(exception != null && _ActiveExceptionsList.Contains(exception))) // Skip this line if its already been done.
 				{
-					// check and or alter the exception is its and HTTPOperationExecption. 
+					// check and or alter the exception is its and HTTPOperationExecption.
 					if (exception is HttpOperationException httpOperationException)
 					{
 						JObject contentBody = JObject.Parse(httpOperationException.Response.Content);
@@ -177,7 +177,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 						LastException = exception;
 				}
 			}
-			_ActiveExceptionsList.Add(exception); 
+			_ActiveExceptionsList.Add(exception);
 
 			detailedDump.Clear();
 			lastMessage.Clear();
@@ -207,7 +207,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		}
 
 		/// <summary>
-		/// Logs data to memory. 
+		/// Logs data to memory.
 		/// </summary>
 		/// <param name="eventType"></param>
 		/// <param name="id"></param>
@@ -239,7 +239,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 						{
 							Tuple<DateTime, string> tos;
 							Logs.TryDequeue(out tos);
-							Debug.WriteLine($"Flushing LogEntry from memory: {tos.Item2}");  // Write flush events out to debug log. 
+							Debug.WriteLine($"Flushing LogEntry from memory: {tos.Item2}");  // Write flush events out to debug log.
 							tos = null;
 						}
 						else
@@ -325,7 +325,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 				{
 					if (objException is HttpOperationException httpOperationException)
 					{
-						JObject contentBody = null; 
+						JObject contentBody = null;
 						if (!string.IsNullOrEmpty(httpOperationException.Response.Content))
 							contentBody = JObject.Parse(httpOperationException.Response.Content);
 
@@ -340,7 +340,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 
 						lastErrorMsg.Append(string.IsNullOrEmpty(httpOperationException.Message) ? "Not Provided" : httpOperationException.Message.ToString().Trim());
 
-						// WebEx currently only returns 1 level of error. 
+						// WebEx currently only returns 1 level of error.
 						var InnerError = contentBody?["error"]["innererror"];
 						if (lastErrorMsg.Length > 0 && InnerError != null)
 						{
@@ -365,7 +365,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 								cdsOpExecp.HResult == -1 ? "Not Provided" : cdsOpExecp.HResult.ToString().Trim(),
 								cdsOpExecp.Data,
 								string.IsNullOrEmpty(cdsOpExecp.HelpLink) ? "Not Provided" : cdsOpExecp.HelpLink.ToString().Trim(),
-								sw, 
+								sw,
 								level);
 
 							lastErrorMsg.Append(string.IsNullOrEmpty(cdsOpExecp.Message) ? "Not Provided" : cdsOpExecp.Message.ToString().Trim());
@@ -413,7 +413,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 			if (enumerable != null)
             {
 				List<string> lst = new List<string>(enumerable);
-				
+
                 foreach (var itm in lst.Distinct())
                 {
 					if (string.IsNullOrEmpty(sOut))
@@ -422,11 +422,11 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 						sOut += $"|{itm}";
 				}
             }
-			return sOut; 
+			return sOut;
         }
 
         /// <summary>
-        /// returns the first line from the text block. 
+        /// returns the first line from the text block.
         /// </summary>
         /// <param name="textBlock"></param>
         /// <returns></returns>
@@ -434,14 +434,19 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         {
 			if (!string.IsNullOrEmpty(textBlock))
 			{
-				if (textBlock.Contains(Environment.NewLine))
-					return textBlock.Substring(0, textBlock.IndexOf(Environment.NewLine)); 
+				try
+				{
+					int iCopyToo = textBlock.IndexOf(Environment.NewLine);
+					if (iCopyToo > 0)
+						return textBlock.Substring(0, textBlock.IndexOf(Environment.NewLine));
+				}
+				catch { } // No Op let it fall though
 			}
 			return textBlock;
         }
 
 		/// <summary>
-		/// Formats the detail collection from a service exception. 
+		/// Formats the detail collection from a service exception.
 		/// </summary>
 		/// <param name="errorDetails"></param>
 		/// <returns></returns>
@@ -462,7 +467,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		}
 
 		/// <summary>
-		/// Creates the exception message. 
+		/// Creates the exception message.
 		/// </summary>
 		/// <param name="source">Source of Exception</param>
 		/// <param name="targetSite">Target of Exception</param>
@@ -555,7 +560,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                 case TraceEventType.Information:
 					return LogLevel.Information;
                 case TraceEventType.Verbose:
-					return LogLevel.Trace;
+					return LogLevel.Debug;
                 default:
 					return LogLevel.None;
             }
@@ -563,15 +568,15 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 
 	}
 
-	/// <summary> 
-	/// This class provides an override for the default trace settings.  
-	/// These settings must be set before the components in the control are used for them to be effective.  
-	/// </summary> 
+	/// <summary>
+	/// This class provides an override for the default trace settings.
+	/// These settings must be set before the components in the control are used for them to be effective.
+	/// </summary>
 	public class TraceControlSettings
 	{
 		private static string _traceSourceName = "Microsoft.PowerPlatform.Dataverse.Client.ServiceClient";
 
-		/// <summary> 
+		/// <summary>
 		/// Returns the Registered Trace Listeners in the override object.
 		/// </summary>
 		internal static Dictionary<string, TraceListener> RegisterdTraceListeners
@@ -582,22 +587,22 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 					TraceSourceSettingStore.GetTraceSourceSettings(_traceSourceName).TraceListeners : null;
 			}
 		}
-		/// <summary> 
+		/// <summary>
 		/// Override Trace Level setting.
-		/// </summary> 
+		/// </summary>
 		public static SourceLevels TraceLevel { get; set; }
-		/// <summary> 
-		/// Builds the base trace settings 
-		/// </summary> 
+		/// <summary>
+		/// Builds the base trace settings
+		/// </summary>
 
 		static TraceControlSettings()
 		{
 			TraceLevel = SourceLevels.Off;
 		}
 
-		/// <summary> 
-		/// Closes any trace listeners that were configured  
-		/// </summary> 
+		/// <summary>
+		/// Closes any trace listeners that were configured
+		/// </summary>
 		public static void CloseListeners()
 		{
 			if (RegisterdTraceListeners != null && RegisterdTraceListeners.Count > 0)
@@ -606,8 +611,8 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 					itm.Close();
 				}
 		}
-		/// <summary> 
-		/// Adds a listener to the trace listen array  
+		/// <summary>
+		/// Adds a listener to the trace listen array
 		/// </summary>
 		/// <param name="listenerToAdd">Trace Listener you wish to add</param>
 		/// <returns>true on success, false on fail.</returns>

--- a/src/GeneralTools/DataverseClient/Client/Utils/Utils.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/Utils.cs
@@ -473,6 +473,14 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                             var attributeInfo = mUtil.GetAttributeMetadata(sourceEntity.LogicalName, key.ToLower());
                             if (attributeInfo is Xrm.Sdk.Metadata.LookupAttributeMetadata attribData)
                             {
+                                // This will not work for Polymorphic currently.
+                                var eData = mUtil.GetEntityMetadata(Xrm.Sdk.Metadata.EntityFilters.Relationships, sourceEntity.LogicalName);
+                                var ERNavName = eData.ManyToOneRelationships.FirstOrDefault(w => w.ReferencingAttribute.Equals(attribData.LogicalName) &&
+                                                                               w.ReferencedEntity.Equals(attribData.Targets.FirstOrDefault()))
+                                                                               ?.ReferencingEntityNavigationPropertyName;
+                                if (!string.IsNullOrEmpty(ERNavName))
+                                    key = ERNavName;
+
                                 // Populate Key property
                                 key = $"{key}@odata.bind";
                             }

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
@@ -8,6 +8,13 @@ Notice:
     Note: that only OAuth, Certificate, ClientSecret Authentication types are supported at this time.
 
 ++CURRENTRELEASEID++
+Fixed Connection Creation "Hang" behavior that could occur when trying to create a Dataverse Service Client inside a thread.
+Fixed an issue with ILogger not propagating correctly when used with connection string flows.
+Fixed an issue when attempting to Null a lookup that would cause a Microsoft.OData.ODataException: Does not support untyped value in non-open type error 
+Changed the behavior of Update message to be consistent with Organization Service Update behavior instead of an Upsert behavior.
+Added compensating code to deal with a null ref issue when logging which could cause a client crash.
+
+0.4.19:
 Updated behavior of ImportSolutionAsync to leverage updated Dataverse behavior post 9.2 release.
 Updated Display name for Northamerica 2 Region to reflect that it is more commonly know as GCC. 
 Updated Newtonsoft.Json to v11.0.2 to match server.


### PR DESCRIPTION
Fixed Connection Creation "Hang" behavior that could occur when trying to create a Dataverse Service Client inside a thread.
Fixed an issue with ILogger not propagating correctly when used with connection string flows.
Fixed an issue when attempting to Null a lookup that would cause a Microsoft.OData.ODataException: Does not support untyped value in non-open type error
Changed the behavior of Update message to be consistent with Organization Service Update behavior instead of an Upsert behavior.
Added compensating code to deal with a null ref issue when logging which could cause a client crash.

Fix #113
Fix #147
Fix #139
Fix #140
Fix #149
