### PR TITLE
Interface Update - Bug fix for External Auth. 

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/Interfaces/IOrganizationServiceAsync2.cs
+++ b/src/GeneralTools/DataverseClient/Client/Interfaces/IOrganizationServiceAsync2.cs
@@ -11,8 +11,24 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 	/// Interface containing extension methods provided by the DataverseServiceClient for the IOrganizationService Interface.
 	/// These extensions will only operate from within the client and are not supported server side.
 	/// </summary>
-	public interface IOrganizationServiceAsync2
+	public interface IOrganizationServiceAsync2 : IOrganizationServiceAsync
 	{
+		/// <summary>
+		/// Associate an entity with a set of entities
+		/// </summary>
+		/// <param name="entityName"></param>
+		/// <param name="entityId"></param>
+		/// <param name="relationship"></param>
+		/// <param name="relatedEntities"></param>
+		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+		Task AssociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities, CancellationToken cancellationToken);
+		/// <summary>
+		/// Create an entity and process any related entities
+		/// </summary>
+		/// <param name="entity">entity to create</param>
+		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+		/// <returns>The ID of the created record</returns>
+		Task<Guid> CreateAsync(Entity entity, CancellationToken cancellationToken);
 		/// <summary>
 		/// Create an entity and process any related entities
 		/// </summary>
@@ -20,6 +36,51 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
 		/// <returns>Returns the newly created record</returns>
 		Task<Entity> CreateAndReturnAsync(Entity entity, CancellationToken cancellationToken);
-
+		/// <summary>
+		/// Delete instance of an entity
+		/// </summary>
+		/// <param name="entityName">Logical name of entity</param>
+		/// <param name="id">Id of entity</param>
+		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+		Task DeleteAsync(string entityName, Guid id, CancellationToken cancellationToken);
+		/// <summary>
+		/// Disassociate an entity with a set of entities
+		/// </summary>
+		/// <param name="entityName"></param>
+		/// <param name="entityId"></param>
+		/// <param name="relationship"></param>
+		/// <param name="relatedEntities"></param>
+		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+		Task DisassociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities, CancellationToken cancellationToken);
+		/// <summary>
+		/// Perform an action in an organization specified by the request.
+		/// </summary>
+		/// <param name="request">Refer to SDK documentation for list of messages that can be used.</param>
+		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+		/// <returns>Results from processing the request</returns>
+		Task<OrganizationResponse> ExecuteAsync(OrganizationRequest request, CancellationToken cancellationToken);
+		/// <summary>
+		/// Retrieves instance of an entity
+		/// </summary>
+		/// <param name="entityName">Logical name of entity</param>
+		/// <param name="id">Id of entity</param>
+		/// <param name="columnSet">Column Set collection to return with the request</param>
+		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+		/// <returns>Selected Entity</returns>
+		Task<Entity> RetrieveAsync(string entityName, Guid id, ColumnSet columnSet, CancellationToken cancellationToken);
+		/// <summary>
+		/// Retrieves a collection of entities
+		/// </summary>
+		/// <param name="query"></param>
+		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+		/// <returns>Returns an EntityCollection Object containing the results of the query</returns>
+		Task<EntityCollection> RetrieveMultipleAsync(QueryBase query, CancellationToken cancellationToken);
+		/// <summary>
+		/// Updates an entity and process any related entities
+		/// </summary>
+		/// <param name="entity">entity to update</param>
+		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+		Task UpdateAsync(Entity entity, CancellationToken cancellationToken);
 	}
+
 }

--- a/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/ServiceClientTests.cs
+++ b/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/ServiceClientTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.PowerPlatform.Dataverse.Client.Auth;
+using Microsoft.PowerPlatform.Dataverse.Client.Utils;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
@@ -213,6 +214,21 @@ namespace Client_Core_Tests
             // Test low level create
             respId = cli.Create(acctEntity);
             Assert.Equal(testSupport._DefaultId, respId);
+
+            // Test low level createAsync
+            respId = cli.CreateAsync(acctEntity).GetAwaiter().GetResult();
+            Assert.Equal(testSupport._DefaultId, respId);
+
+            try
+            {
+                // Test low level createAsyncwithCancelationToken
+                System.Threading.CancellationToken tok = new System.Threading.CancellationToken(true);
+                respId = cli.CreateAsync(acctEntity, tok).GetAwaiter().GetResult();
+            }
+            catch(Exception ex)
+            {
+                Assert.IsType<OperationCanceledException>(ex);
+            }
 
             // Test Helper create
             respId = cli.CreateNewRecord("account", newFields);

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
@@ -8,6 +8,16 @@ Notice:
     Note: that only OAuth, Certificate, ClientSecret Authentication types are supported at this time.
 
 ++CURRENTRELEASEID++
+Fixed and issue with the client being non-castable to IOrganizationServiceAsync, Client will now cast again. (Internal Report)
+    Special note: 
+        IOrganizationServiceAsync has async methods without cancellation support. this is required for service mapping as the dataverse server does not natively support this feature. 
+        IOrganizationServiceAsync2 has async methods WITH cancellation support.  
+        This surfaces in the client as 2 forms of each async method and is currently necessary to support internal auto generation of contracts for service communication. We will work to improve this in the future.
+        Cancellation events will currently raise an OperationCancelled Exception, this can either be the topmost exception, or embedded in a DataverseException.
+        Cancellation methods are 'preferred' if you need to support cancellation in your application.
+Fixed an issue with External authentication type not being properly passed though to cloned clients.  (git #162)
+
+0.5.2:
 ***** Breaking Changes *****
 Removed the constructor:
     public ServiceClient(OrganizationWebProxyClient externalOrgWebProxyClient, ILogger logger = null)


### PR DESCRIPTION
Fixed and issue with the client being non-castable to IOrganizationServiceAsync, Client will now cast again. (Internal Report)
- Special note: 
   - IOrganizationServiceAsync has async methods without cancellation support. this is required for service mapping as the dataverse server does not natively support this feature. 
   - IOrganizationServiceAsync2 has async methods WITH cancellation support. 
     - This surfaces in the client as 2 forms of each async method and is currently necessary to support internal auto generation of contracts for service communication. We will work to improve this in the future.
     - Cancellation events will currently raise an OperationCancelled Exception, this can either be the topmost exception, or embedded in a DataverseException.
     - Cancellation methods are 'preferred' if you need to support cancellation in your application.

Fixed an issue with External authentication type not being properly passed though to cloned clients.  Fixed #162 
