### PR TITLE
Fix NullReferenceException if the connection string is missing RedirectUri

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/Auth/AuthProcessor.cs
+++ b/src/GeneralTools/DataverseClient/Client/Auth/AuthProcessor.cs
@@ -183,7 +183,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
                             {
                                 ClientId = clientId,
                                 EnablePiiLogging = true,
-                                RedirectUri = redirectUri.ToString(),
+                                RedirectUri = redirectUri?.ToString(),
                                 LogLevel = LogLevel.Verbose,
                             })
                         .WithAuthority(Authority)


### PR DESCRIPTION
Can be easily reproduced with the following code:
```c#
new ServiceClient("Url=https://lanxess.crm4.dynamics.com;AuthType=OAuth;AppId=51f81489-12ee-4a9e-aaae-a2591f45987d")
```