### PR TITLE
Simplify accessing assembly versions

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/Auth/AuthProcessor.cs
+++ b/src/GeneralTools/DataverseClient/Client/Auth/AuthProcessor.cs
@@ -431,7 +431,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
             }
 
             UriBuilder versionTaggedUriBuilder = new UriBuilder(webUrlBuilder.Uri);
-            string version = FileVersionInfo.GetVersionInfo(typeof(Xrm.Sdk.Organization.OrganizationDetail).Assembly.Location).FileVersion;
+            string version = Utilities.GetXrmSdkAssemblyFileVersion();
             string versionQueryStringParameter = string.Format("SDKClientVersion={0}", version);
 
             if (string.IsNullOrEmpty(versionTaggedUriBuilder.Query))

--- a/src/GeneralTools/DataverseClient/Client/Auth/TokenCache/FileBackedTokenCacheHints.cs
+++ b/src/GeneralTools/DataverseClient/Client/Auth/TokenCache/FileBackedTokenCacheHints.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth.TokenCache
             {
                 hostName = Path.GetFileNameWithoutExtension(AppDomain.CurrentDomain.FriendlyName);
             }
-            string hostVersion = typeof(OrganizationDetail).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version ?? FileVersionInfo.GetVersionInfo(typeof(OrganizationDetail).Assembly.Location).FileVersion;
+            string hostVersion = Utilities.GetXrmSdkAssemblyFileVersion();
             string companyName = typeof(OrganizationDetail).Assembly.GetCustomAttribute<AssemblyCompanyAttribute>().Company;
 
 

--- a/src/GeneralTools/DataverseClient/Client/Connector/OnPremises/OrganizationServiceProxyAsync.cs
+++ b/src/GeneralTools/DataverseClient/Client/Connector/OnPremises/OrganizationServiceProxyAsync.cs
@@ -39,8 +39,6 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         public string SdkClientVersion { get; set; }
 
-        private static string _xrmSdkAssemblyFileVersion;
-
         internal OrganizationServiceProxyAsync()
         {
         }
@@ -99,45 +97,6 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
             ClientExceptionHelper.ThrowIfNull(orgConfig, "orgConfig");
 
             orgConfig.EnableProxyTypes(assembly);
-        }
-
-        /// <summary>
-        /// Get's the file version of the Xrm Sdk assembly that is loaded in the current client domain.
-        /// For Sdk clients called via the OrganizationServiceProxy this is the version of the local Microsoft.Xrm.Sdk dll used by the Client App.
-        /// </summary>
-        /// <returns></returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2143:TransparentMethodsShouldNotDemandFxCopRule")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2141:TransparentMethodsMustNotSatisfyLinkDemandsFxCopRule")]
-        [PermissionSet(SecurityAction.Demand, Unrestricted = true)]
-        internal static string GetXrmSdkAssemblyFileVersion()
-        {
-            if (string.IsNullOrEmpty(_xrmSdkAssemblyFileVersion))
-            {
-                string[] assembliesToCheck = new string[] { "Microsoft.Xrm.Sdk.dll" };
-                Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
-
-                foreach (var assemblyToCheck in assembliesToCheck)
-                {
-                    foreach (Assembly assembly in assemblies)
-                    {
-                        if (assembly.ManifestModule.Name.Equals(assemblyToCheck, StringComparison.OrdinalIgnoreCase) &&
-                                !string.IsNullOrEmpty(assembly.Location) &&
-                                System.IO.File.Exists(assembly.Location))
-                        {
-                            _xrmSdkAssemblyFileVersion = FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // If the assembly is embedded as resource and loaded from memory, there is no physical file on disk to check for file version
-            if (string.IsNullOrEmpty(_xrmSdkAssemblyFileVersion))
-            {
-                _xrmSdkAssemblyFileVersion = "9.1.2.3";
-            }
-
-            return _xrmSdkAssemblyFileVersion;
         }
 
         #endregion Public Members

--- a/src/GeneralTools/DataverseClient/Client/Connector/OnPremises/OrganizationServiceProxyContextAsyncInitializer.cs
+++ b/src/GeneralTools/DataverseClient/Client/Connector/OnPremises/OrganizationServiceProxyContextAsyncInitializer.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
                 }
                 else
                 {
-                    string fileVersion = OrganizationServiceProxyAsync.GetXrmSdkAssemblyFileVersion();
+                    string fileVersion = Utilities.GetXrmSdkAssemblyFileVersion();
                     if (!string.IsNullOrEmpty(fileVersion))
                     {
                         OperationContext.Current.OutgoingMessageHeaders.Add(MessageHeader.CreateHeader(SdkHeaders.SdkClientVersion,

--- a/src/GeneralTools/DataverseClient/Client/Connector/WebProxyClient.cs
+++ b/src/GeneralTools/DataverseClient/Client/Connector/WebProxyClient.cs
@@ -13,12 +13,6 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector
     internal abstract class WebProxyClientAsync<TService> : ClientBase<TService>, IDisposable
         where TService : class
     {
-        #region Fields
-
-        private string _xrmSdkAssemblyFileVersion;
-
-        #endregion
-
         protected WebProxyClientAsync(Uri serviceUrl, bool useStrongTypes)
             : base(CreateServiceEndpoint(serviceUrl, useStrongTypes, Utilites.DefaultTimeout, null))
         {
@@ -154,46 +148,6 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector
             binding.ReaderQuotas.MaxNameTableCharCount = int.MaxValue;
 
             return binding;
-        }
-
-        /// <summary>
-        ///     Get's the file version of the Xrm Sdk assembly that is loaded in the current client domain.
-        ///     For Sdk clients called via the OrganizationServiceProxy this is the version of the local Microsoft.Xrm.Sdk dll used
-        ///     by the Client App.
-        /// </summary>
-        /// <returns></returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2143:TransparentMethodsShouldNotDemandFxCopRule")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2141:TransparentMethodsMustNotSatisfyLinkDemandsFxCopRule")]
-        [PermissionSet(SecurityAction.Demand, Unrestricted = true)]
-        internal string GetXrmSdkAssemblyFileVersion()
-        {
-            if (string.IsNullOrEmpty(_xrmSdkAssemblyFileVersion))
-            {
-                string[] assembliesToCheck = { "Microsoft.Xrm.Sdk.dll" };
-                Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
-
-                foreach (string assemblyToCheck in assembliesToCheck)
-                {
-                    foreach (Assembly assembly in assemblies)
-                    {
-                        if (assembly.ManifestModule.Name.Equals(assemblyToCheck, StringComparison.OrdinalIgnoreCase) &&
-                                !string.IsNullOrEmpty(assembly.Location) &&
-                                System.IO.File.Exists(assembly.Location))
-                        {
-                            _xrmSdkAssemblyFileVersion = FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // If the assembly is embedded as resource and loaded from memory, there is no physical file on disk to check for file version
-            if (string.IsNullOrEmpty(_xrmSdkAssemblyFileVersion))
-            {
-                _xrmSdkAssemblyFileVersion = "9.1.2.3";
-            }
-
-            return _xrmSdkAssemblyFileVersion;
         }
 
         #region IDisposable implementation

--- a/src/GeneralTools/DataverseClient/Client/Connector/WebProxyClientContextInitializer.cs
+++ b/src/GeneralTools/DataverseClient/Client/Connector/WebProxyClientContextInitializer.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector
             }
             else
             {
-                string fileVersion = ServiceProxy.GetXrmSdkAssemblyFileVersion();
+                string fileVersion = Utilities.GetXrmSdkAssemblyFileVersion();
                 if (!string.IsNullOrEmpty(fileVersion))
                 {
                     OperationContext.Current.OutgoingMessageHeaders.Add(MessageHeader.CreateHeader(SdkHeaders.SdkClientVersion,

--- a/src/GeneralTools/DataverseClient/Client/Environs.cs
+++ b/src/GeneralTools/DataverseClient/Client/Environs.cs
@@ -5,37 +5,6 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 {
     internal static class Environs
     {
-        private static object _initLock = new object();
-
-        public static string FileVersion { get; private set; }
-
-        static Environs()
-        {
-            if (string.IsNullOrEmpty(FileVersion))
-            {
-                lock (_initLock)
-                {
-                    if (string.IsNullOrEmpty(FileVersion))
-                    {
-                        FileVersion = "Unknown";
-                        try
-                        {
-                            string location = Assembly.GetExecutingAssembly().Location;
-                            if (!string.IsNullOrEmpty(location))
-                            {
-                                string version = FileVersionInfo.GetVersionInfo(location).FileVersion;
-                                if (!string.IsNullOrEmpty(version))
-                                {
-                                    FileVersion = version;
-                                }
-                            }
-                        }
-                        catch
-                        {
-                        }
-                    }
-                }
-            }
-        }
+        public static string FileVersion => Utilities.GetAssemblyFileVersion(Assembly.GetExecutingAssembly());
     }
 }

--- a/src/GeneralTools/DataverseClient/Client/ServiceClient.cs
+++ b/src/GeneralTools/DataverseClient/Client/ServiceClient.cs
@@ -577,7 +577,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             {
                 if (string.IsNullOrEmpty(_sdkVersionProperty))
                 {
-                    _sdkVersionProperty = typeof(OrganizationDetail).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version ?? FileVersionInfo.GetVersionInfo(typeof(OrganizationDetail).Assembly.Location).FileVersion;
+                    _sdkVersionProperty = Utilities.GetXrmSdkAssemblyFileVersion();
                 }
                 return _sdkVersionProperty;
             }


### PR DESCRIPTION
Use the same method everywhere an assembly version is required in order not to use`FileVersionInfo.GetVersionInfo` directly, which is not compatible with single file applications whose assembly.Location always return an empty string. (It was still used directly in the `AuthProcessor` class)

Also, use GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version with a question mark before acessing the `.Version` property in order to fallback to version on disk rather than crashing with a null reference exception. (The ? was missing in both Microsoft.PowerPlatform.Dataverse.Client.ServiceClient.SdkVersionProperty and Microsoft.PowerPlatform.Dataverse.Client.Auth.TokenCache.FileBackedTokenCacheHints.FileBackedTokenCacheHints)