### PR TITLE
Actually parse the "Integrated Security" connection string part

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/Utils/DataverseConnectionStringProcessor.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/DataverseConnectionStringProcessor.cs
@@ -254,6 +254,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             bool _IntegratedSecurity = false;
             if (!string.IsNullOrEmpty(IntegratedSecurity))
                 bool.TryParse(IntegratedSecurity, out _IntegratedSecurity);
+            UseCurrentUser = _IntegratedSecurity;
 
             bool useUniqueConnection = true;  // Set default to true to follow the old behavior.
             if (!string.IsNullOrEmpty(requireNewInstance))


### PR DESCRIPTION
Assign the result of parsing the "Integrated Security" setting to the `DataverseConnectionStringProcessor.UseCurrentUser` property. The "Integrated Security" part was parsed but the result was not used and the `UseCurrentUser` existed but was never assigned. I'm pretty sure that it was intended to be like this, especially with the comment above parsing of the IntegratedSecurity:
> // Check to see if use current user is configured.