### PR TITLE
SyncUp to Main Build Branch

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/Auth/AuthProcessor.cs
+++ b/src/GeneralTools/DataverseClient/Client/Auth/AuthProcessor.cs
@@ -402,7 +402,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
                 if (publicAppClient != null)
                 {
                     var accList = await publicAppClient.GetAccountsAsync().ConfigureAwait(false);
-                    if (accList != null && accList.Count() > 0)
+                    if (accList != null && accList.Any())
                     {
                         return accList.FirstOrDefault<IAccount>(w => w.Username.Equals(loginHint, StringComparison.OrdinalIgnoreCase));
                     }

--- a/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
+++ b/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
@@ -21,6 +21,7 @@ using Microsoft.Xrm.Sdk.WebServiceClient;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -611,7 +612,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         /// <summary>
         /// Cookies that are being passed though clients, when cookies are used
         /// </summary>
-        internal Dictionary<string, string> CurrentCookieCollection { get; set; } = null;
+        internal ConcurrentDictionary<string, string> CurrentCookieCollection { get; set; } = null;
 
         /// <summary>
         /// Server Hint for the number of concurrent threads that would provide optimal processing. 
@@ -697,7 +698,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             Uri instanceToConnectToo = null)
         {
             if (authType != AuthenticationType.AD)
-                throw new ArgumentOutOfRangeException("authType", "Invalid Authentication type");
+                throw new ArgumentOutOfRangeException(nameof(authType), "Invalid Authentication type");
 
             if (logSink == null)
             {
@@ -762,7 +763,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             )
         {
             if (authType != AuthenticationType.OAuth && authType != AuthenticationType.ClientSecret)
-                throw new ArgumentOutOfRangeException("authType", "This constructor only supports the OAuth or Client Secret Auth types");
+                throw new ArgumentOutOfRangeException(nameof(authType), "This constructor only supports the OAuth or Client Secret Auth types");
 
             if (logSink == null)
             {
@@ -828,7 +829,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             string tokenCacheStorePath = null)
         {
             if (authType != AuthenticationType.Certificate && authType != AuthenticationType.ExternalTokenManagement)
-                throw new ArgumentOutOfRangeException("authType", "This constructor only supports the Certificate Auth type");
+                throw new ArgumentOutOfRangeException(nameof(authType), "This constructor only supports the Certificate Auth type");
 
             if (logSink == null)
             {
@@ -1345,7 +1346,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                 // Login to Live Failed.
                 logEntry.Log(string.Format(CultureInfo.InvariantCulture, "Invalid Login Information : {0}", ex.Message),
                                TraceEventType.Error, ex);
-                throw ex;
+                throw;
 
             }
             catch (WebException ex)
@@ -1362,7 +1363,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                     logEntry.Log(string.Format(CultureInfo.InvariantCulture, "Unable to connect to Dataverse: {0}", ex.Message), TraceEventType.Error, ex);
 
                 }
-                throw ex;
+                throw;
             }
             catch (InvalidOperationException ex)
             {
@@ -1370,7 +1371,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                     logEntry.Log(string.Format(CultureInfo.InvariantCulture, "Unable to connect to Dataverse: {0}", ex.Message), TraceEventType.Error, ex);
                 else
                     logEntry.Log(string.Format(CultureInfo.InvariantCulture, "Unable to connect to Dataverse: {0}", ex.InnerException.Message), TraceEventType.Error, ex);
-                throw ex;
+                throw;
             }
             catch (Exception ex)
             {
@@ -1378,7 +1379,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                     logEntry.Log(string.Format(CultureInfo.InvariantCulture, "Unable to connect to Dataverse: {0}", ex.Message), TraceEventType.Error, ex);
                 else
                     logEntry.Log(string.Format(CultureInfo.InvariantCulture, "Unable to connect to Dataverse: {0}", ex.InnerException.Message), TraceEventType.Error, ex);
-                throw ex;
+                throw;
             }
             finally
             {
@@ -1679,7 +1680,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         internal void SetClonedProperties(ServiceClient sourceClient)
         {
             if (sourceClient is null)
-                throw new ArgumentNullException("sourceClient");
+                throw new ArgumentNullException(nameof(sourceClient));
 
             if (sourceClient._connectionSvc is null)
                 throw new NullReferenceException("Source Connection Service is Failed, Cannot create a clone.");
@@ -2097,7 +2098,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                 if (CallerAADObjectId.HasValue)
                 {
                     // Value in Caller object ID.
-                    if (CallerAADObjectId.Value != null && CallerAADObjectId.Value != Guid.Empty)
+                    if (CallerAADObjectId.Value != Guid.Empty)
                     {
                         customHeaders.Add(Utilities.RequestHeaders.AAD_CALLER_OBJECT_ID_HTTP_HEADER, new List<string>() { CallerAADObjectId.ToString() });
                     }
@@ -2727,7 +2728,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                 }
 
                 if (discoveryServiceUri == null)
-                    throw new ArgumentNullException("discoveryServiceUri", "Discovery service uri cannot be null.");
+                    throw new ArgumentNullException(nameof(discoveryServiceUri), "Discovery service uri cannot be null.");
 
                 // if the discovery URL does not contain api/discovery , base it and use it in the commercial format base.
                 // Check needs to be in 2 places as there are 2 different ways Auth can occur.
@@ -2790,7 +2791,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             }
 
             if (discoveryServiceUri == null)
-                throw new ArgumentNullException("discoveryServiceUri", "Discovery service uri cannot be null.");
+                throw new ArgumentNullException(nameof(discoveryServiceUri), "Discovery service uri cannot be null.");
 
             Stopwatch dtStartQuery = new Stopwatch();
             dtStartQuery.Start();

--- a/src/GeneralTools/DataverseClient/Client/Connector/OnPremises/OrganizationServiceProxyAsync.cs
+++ b/src/GeneralTools/DataverseClient/Client/Connector/OnPremises/OrganizationServiceProxyAsync.cs
@@ -194,7 +194,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         protected internal virtual async Task<Guid> CreateAsyncCore(Entity entity)
         {
-            return await ExecuteOperation<Guid>(async () => { await ServiceChannel.Channel.CreateAsync(entity).ConfigureAwait(false); });
+            return await ExecuteOperation<Guid>(async () => { await ServiceChannel.Channel.CreateAsync(entity).ConfigureAwait(false); }).ConfigureAwait(false);
         }
 
         protected internal virtual Entity RetrieveCore(string entityName, Guid id, ColumnSet columnSet)
@@ -263,7 +263,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         protected internal virtual async Task<Entity> RetrieveAsyncCore(string entityName, Guid id, ColumnSet columnSet)
         {
-            return await ExecuteOperation<Entity>(async () => { await ServiceChannel.Channel.RetrieveAsync(entityName, id, columnSet).ConfigureAwait(false); });
+            return await ExecuteOperation<Entity>(async () => { await ServiceChannel.Channel.RetrieveAsync(entityName, id, columnSet).ConfigureAwait(false); }).ConfigureAwait(false);
         }
 
         protected internal virtual void UpdateCore(Entity entity)
@@ -333,7 +333,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         protected internal virtual async Task UpdateAsyncCore(Entity entity)
         {
-            _ = await ExecuteOperation<bool?>(async () => { await ServiceChannel.Channel.UpdateAsync(entity).ConfigureAwait(false); });
+            _ = await ExecuteOperation<bool?>(async () => { await ServiceChannel.Channel.UpdateAsync(entity).ConfigureAwait(false); }).ConfigureAwait(false);
         }
 
         protected internal virtual void DeleteCore(string entityName, Guid id)
@@ -403,7 +403,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         protected internal virtual async Task DeleteAsyncCore(string entityName, Guid id)
         {
-            _ = await ExecuteOperation<bool?>(async () => { await ServiceChannel.Channel.DeleteAsync(entityName, id).ConfigureAwait(false); });
+            _ = await ExecuteOperation<bool?>(async () => { await ServiceChannel.Channel.DeleteAsync(entityName, id).ConfigureAwait(false); }).ConfigureAwait(false);
         }
 
         protected internal virtual OrganizationResponse ExecuteCore(OrganizationRequest request)
@@ -472,7 +472,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         protected internal virtual async Task<OrganizationResponse> ExecuteAsyncCore(OrganizationRequest request)
         {
-            return await ExecuteOperation<OrganizationResponse>(async () => { await ServiceChannel.Channel.ExecuteAsync(request).ConfigureAwait(false); });
+            return await ExecuteOperation<OrganizationResponse>(async () => { await ServiceChannel.Channel.ExecuteAsync(request).ConfigureAwait(false); }).ConfigureAwait(false);
         }
 
         protected internal virtual void AssociateCore(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities)
@@ -542,7 +542,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         protected internal virtual async Task AssociateAsyncCore(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities)
         {
-            await ExecuteOperation<OrganizationResponse>(async () => { await ServiceChannel.Channel.AssociateAsync(entityName, entityId, relationship, relatedEntities).ConfigureAwait(false); });
+            await ExecuteOperation<OrganizationResponse>(async () => { await ServiceChannel.Channel.AssociateAsync(entityName, entityId, relationship, relatedEntities).ConfigureAwait(false); }).ConfigureAwait(false);
         }
 
         protected internal virtual void DisassociateCore(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities)
@@ -612,7 +612,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         protected internal virtual async Task DisassociateAsyncCore(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities)
         {
-            await ExecuteOperation<OrganizationResponse>(async () => { await ServiceChannel.Channel.DisassociateAsync(entityName, entityId, relationship, relatedEntities).ConfigureAwait(false); });
+            await ExecuteOperation<OrganizationResponse>(async () => { await ServiceChannel.Channel.DisassociateAsync(entityName, entityId, relationship, relatedEntities).ConfigureAwait(false); }).ConfigureAwait(false);
         }
 
         protected internal virtual EntityCollection RetrieveMultipleCore(QueryBase query)
@@ -681,7 +681,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         protected internal virtual async Task<EntityCollection> RetrieveMultipleAsyncCore(QueryBase query)
         {
-            return await ExecuteOperation<EntityCollection>(async () => { await ServiceChannel.Channel.RetrieveMultipleAsync(query).ConfigureAwait(false); });
+            return await ExecuteOperation<EntityCollection>(async () => { await ServiceChannel.Channel.RetrieveMultipleAsync(query).ConfigureAwait(false); }).ConfigureAwait(false);
         }
 
         protected async internal Task<T> ExecuteOperation<T>(Func<Task> asyncAction)
@@ -759,7 +759,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         public async Task<Guid> CreateAsync(Entity entity)
         {
-            return await CreateAsyncCore(entity);
+            return await CreateAsyncCore(entity).ConfigureAwait(false);
         }
 
         public Entity Retrieve(string entityName, Guid id, ColumnSet columnSet)
@@ -768,7 +768,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
         }
         public async Task<Entity> RetrieveAsync(string entityName, Guid id, ColumnSet columnSet)
         {
-            return await RetrieveAsyncCore(entityName, id, columnSet);
+            return await RetrieveAsyncCore(entityName, id, columnSet).ConfigureAwait(false);
         }
 
         public void Update(Entity entity)
@@ -777,7 +777,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
         }
         public async Task UpdateAsync(Entity entity)
         {
-            await UpdateAsyncCore(entity);
+            await UpdateAsyncCore(entity).ConfigureAwait(false);
         }
 
         public void Delete(string entityName, Guid id)
@@ -787,7 +787,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         public async Task DeleteAsync(string entityName, Guid id)
         {
-            await DeleteAsyncCore(entityName, id);
+            await DeleteAsyncCore(entityName, id).ConfigureAwait(false);
         }
 
 
@@ -798,7 +798,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         public async Task<OrganizationResponse> ExecuteAsync(OrganizationRequest request)
         {
-            return await ExecuteAsyncCore(request);
+            return await ExecuteAsyncCore(request).ConfigureAwait(false);
         }
 
         public void Associate(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities)
@@ -808,7 +808,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         public async Task AssociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities)
         {
-            await AssociateAsyncCore(entityName, entityId, relationship, relatedEntities);
+            await AssociateAsyncCore(entityName, entityId, relationship, relatedEntities).ConfigureAwait(false);
         }
 
         public void Disassociate(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities)
@@ -818,7 +818,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         public async Task DisassociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities)
         {
-            await DisassociateAsyncCore(entityName, entityId, relationship, relatedEntities);
+            await DisassociateAsyncCore(entityName, entityId, relationship, relatedEntities).ConfigureAwait(false);
         }
 
         public EntityCollection RetrieveMultiple(QueryBase query)
@@ -828,7 +828,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Connector.OnPremises
 
         public async Task<EntityCollection> RetrieveMultipleAsync(QueryBase query)
         {
-            return await RetrieveMultipleAsyncCore(query);
+            return await RetrieveMultipleAsyncCore(query).ConfigureAwait(false);
         }
 
         #endregion

--- a/src/GeneralTools/DataverseClient/Client/DataverseTraceLogger.cs
+++ b/src/GeneralTools/DataverseClient/Client/DataverseTraceLogger.cs
@@ -393,7 +393,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                 FormatExceptionMessage(
                 OrgFault.Source != null ? OrgFault.Source.ToString().Trim() : "Not Provided",
                 OrgFault.TargetSite != null ? OrgFault.TargetSite.Name.ToString() : "Not Provided",
-                OrgFault.Detail != null ? string.Format(CultureInfo.InvariantCulture, "Message: {0}\nErrorCode: {1}{4}\nTrace: {2}{3}", OrgFault.Detail.Message, OrgFault.Detail.ErrorCode, OrgFault.Detail.TraceText, string.IsNullOrEmpty(ErrorDetail) ? "" : $"\n{ErrorDetail}", OrgFault.Detail.ActivityId == null ? "" : $"\nActivityId: {OrgFault.Detail.ActivityId}") :
+                OrgFault.Detail != null ? string.Format(CultureInfo.InvariantCulture, "Message: {0}\nErrorCode: {1}{4}\nTrace: {2}{3}", OrgFault.Detail.Message, OrgFault.Detail.ErrorCode, OrgFault.Detail.TraceText, string.IsNullOrEmpty(ErrorDetail) ? "" : $"\n{ErrorDetail}", OrgFault.Detail.ActivityId != Guid.Empty ? "" : $"\nActivityId: {OrgFault.Detail.ActivityId}") :
                 string.IsNullOrEmpty(OrgFault.Message) ? "Not Provided" : OrgFault.Message.ToString().Trim(),
                 string.IsNullOrEmpty(OrgFault.HelpLink) ? "Not Provided" : OrgFault.HelpLink.ToString().Trim(),
                 string.IsNullOrEmpty(OrgFault.StackTrace) ? "Not Provided" : OrgFault.StackTrace.ToString().Trim()
@@ -420,7 +420,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                     OrganizationServiceFault oFault = (OrganizationServiceFault)objException;
                     string ErrorDetail = GenerateOrgErrorDetailsInfo(oFault.ErrorDetails);
                     FormatOrgFaultMessage(
-                            string.Format(CultureInfo.InvariantCulture, "Message: {0}\nErrorCode: {1}{4}\nTrace: {2}{3}", oFault.Message, oFault.ErrorCode, oFault.TraceText, string.IsNullOrEmpty(ErrorDetail) ? "" : $"\n{ErrorDetail}", oFault.ActivityId == null ? "" : $"\nActivityId: {oFault.ActivityId}"),
+                            string.Format(CultureInfo.InvariantCulture, "Message: {0}\nErrorCode: {1}{4}\nTrace: {2}{3}", oFault.Message, oFault.ErrorCode, oFault.TraceText, string.IsNullOrEmpty(ErrorDetail) ? "" : $"\n{ErrorDetail}", oFault.ActivityId != Guid.Empty ? "" : $"\nActivityId: {oFault.ActivityId}"),
                             oFault.Timestamp.ToString(),
                             oFault.ErrorCode.ToString(),
                             string.IsNullOrEmpty(oFault.HelpLink) ? "Not Provided" : oFault.HelpLink.ToString().Trim(),

--- a/src/GeneralTools/DataverseClient/Client/Microsoft.PowerPlatform.Dataverse.Client.csproj
+++ b/src/GeneralTools/DataverseClient/Client/Microsoft.PowerPlatform.Dataverse.Client.csproj
@@ -42,6 +42,8 @@
     <PackageReference Include="System.Text.Json" Version="6.0.2" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.9" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(PackageVersion_Microsoft_Extensions)" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.3" /> <!-- explict add to deal with CVE-2021-24112  --> 
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.1" /> <!-- explict add to deal with CVE-2022-34716  --> 
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48'">

--- a/src/GeneralTools/DataverseClient/Client/Utils/AppSettingsHelper.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/AppSettingsHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -106,7 +106,17 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Utils
 						return defaultValue;
 				}
 			}
-			finally
+            catch (Exception ex)
+            {
+                if (logSink == null) // building on first use to optimize 
+                {
+                    logSink = new DataverseTraceLogger();
+                    isLogEntryCreatedLocaly = true;
+                }
+                logSink.Log($"Failed to read {key} from AppSettings, failed with message: {ex.Message}.  Using default value", System.Diagnostics.TraceEventType.Warning);
+                return defaultValue;
+            }
+            finally
 			{
 				if (isLogEntryCreatedLocaly)
 					logSink.Dispose();

--- a/src/GeneralTools/DataverseClient/Client/Utils/DataverseConnectionStringProcessor.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/DataverseConnectionStringProcessor.cs
@@ -254,6 +254,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             bool _IntegratedSecurity = false;
             if (!string.IsNullOrEmpty(IntegratedSecurity))
                 bool.TryParse(IntegratedSecurity, out _IntegratedSecurity);
+            UseCurrentUser = _IntegratedSecurity;
 
             bool useUniqueConnection = true;  // Set default to true to follow the old behavior.
             if (!string.IsNullOrEmpty(requireNewInstance))
@@ -289,7 +290,8 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             }
 
             //if the client Id was not passed, use Sample AppID
-            if (authenticationType != AuthenticationType.AD && string.IsNullOrWhiteSpace(ClientId))
+            if ((authenticationType != AuthenticationType.AD || authenticationType != AuthenticationType.ExternalTokenManagement) 
+                && string.IsNullOrWhiteSpace(ClientId))
             {
                 logEntry.Log($"Client ID not supplied, using SDK Sample Client ID for this connection", System.Diagnostics.TraceEventType.Warning);
                 ClientId = sampleClientId;// sample client ID

--- a/src/GeneralTools/DataverseClient/Client/Utils/Utils.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/Utils.cs
@@ -8,6 +8,7 @@ using Microsoft.Xrm.Sdk.Discovery;
 using Microsoft.Xrm.Sdk.Metadata;
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
@@ -1070,7 +1071,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         /// <param name="strHeader">Header string to start with</param>
         /// <param name="cookieCollection">Collection of cookies currently in the system</param>
         /// <returns></returns>
-        internal static Dictionary<string, string> GetAllCookiesFromHeader(string strHeader, Dictionary<string, string> cookieCollection)
+        internal static ConcurrentDictionary<string, string> GetAllCookiesFromHeader(string strHeader, ConcurrentDictionary<string, string> cookieCollection)
         {
             ArrayList al = ConvertCookieHeaderToArrayList(strHeader);
             return ConvertCookieArraysToCookieDictionary(al, cookieCollection);
@@ -1082,7 +1083,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         /// <param name="strHeaderList">Header string to start with</param>
         /// <param name="cookieCollection"> collection of cookies currently in the system</param>
         /// <returns></returns>
-        internal static Dictionary<string, string> GetAllCookiesFromHeader(string[] strHeaderList, Dictionary<string, string> cookieCollection)
+        internal static ConcurrentDictionary<string, string> GetAllCookiesFromHeader(string[] strHeaderList, ConcurrentDictionary<string, string> cookieCollection)
         {
             if (strHeaderList != null)
             {
@@ -1094,7 +1095,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             }
         }
 
-        internal static string GetCookiesFromCollectionAsString(Dictionary<string, string> cookieCollection)
+        internal static string GetCookiesFromCollectionAsString(ConcurrentDictionary<string, string> cookieCollection)
         {
             if (cookieCollection == null || cookieCollection.Count == 0)
                 return string.Empty;
@@ -1110,7 +1111,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             return cookieString;
         }
 
-        internal static List<string> GetCookiesFromCollectionAsArray(Dictionary<string, string> cookieCollection)
+        internal static List<string> GetCookiesFromCollectionAsArray(ConcurrentDictionary<string, string> cookieCollection)
         {
             if (cookieCollection == null || cookieCollection.Count == 0)
                 return null;
@@ -1182,10 +1183,10 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         /// <param name="al"></param>
         /// <param name="cookieCollection"> Cookie collection to populate or update</param>
         /// <returns></returns>
-        private static Dictionary<string, string> ConvertCookieArraysToCookieDictionary(ArrayList al, Dictionary<string, string> cookieCollection)
+        private static ConcurrentDictionary<string, string> ConvertCookieArraysToCookieDictionary(ArrayList al, ConcurrentDictionary<string, string> cookieCollection)
         {
             if (cookieCollection == null)
-                cookieCollection = new Dictionary<string, string>();
+                cookieCollection = new ConcurrentDictionary<string, string>();
 
             int alcount = al.Count;
             string strEachCook;
@@ -1208,7 +1209,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                     if (cookieCollection.ContainsKey(firstName))
                         cookieCollection[firstName] = allValue;
                     else
-                        cookieCollection.Add(firstName, allValue);
+                        cookieCollection.TryAdd(firstName, allValue);
                 }
             }
             return cookieCollection;

--- a/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/ServiceClientTests.cs
+++ b/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/ServiceClientTests.cs
@@ -76,6 +76,27 @@ namespace Client_Core_Tests
         }
 
         [Fact]
+        public void TestThrowDisposedOperationCheck()
+        {
+            Mock<IOrganizationService> orgSvc = null;
+            Mock<MoqHttpMessagehander> fakHttpMethodHander = null;
+            ServiceClient cli = null;
+            testSupport.SetupMockAndSupport(out orgSvc, out fakHttpMethodHander, out cli);
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                cli.Dispose();
+                _ = (WhoAmIResponse)cli.Execute(new WhoAmIRequest());
+            });
+
+            Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                cli.Dispose();
+                _ = (WhoAmIResponse) await cli.ExecuteAsync(new WhoAmIRequest());
+            });
+        }
+
+        [Fact]
         public void ExecuteMessageTests()
         {
             Mock<IOrganizationService> orgSvc = null;

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
@@ -7,6 +7,17 @@ Notice:
     Note: Only AD on FullFramework, OAuth, Certificate, ClientSecret Authentication types are supported at this time.
 
 ++CURRENTRELEASEID++
+Fix by Git user matkov accepted for crash during create when an invalid timespan is passed from a configuration file to the ServiceClient Constructor. See https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/326 for details.
+Fix by GIT user 0xced accepted for bug in Integrated user security setting,  Code will now properly honor integrated security when attempting to authenticate. See https://github.com/microsoft/PowerPlatform-DataverseServiceClient/pull/324 for details. 
+Fixed a number of places where Async Calls did not have a .ConfigureAwait specification. Thanks to user 0xced for prompting this fix. 
+Fixed a misleading warning message "Client ID not supplied, using SDK Sample Client ID for this connection" that would be incorrectly shown when ExternalAuthentication type was used. Fixes https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/314, Thanks for your report! 
+Fixed a possible thread contention issue when managing connection context across multiple concurrent threads in the same client.  Git issue: https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/304 Thanks for your report ! 
+Fixed a memory leak when caused by a logger not being cleaned up when a the creation of the ServiceClient fails. Git issue: https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/322
+Fixed issue where calling the IOrganizationService* interfaces after the client has been disposed would throw a NullReferenceException. Taking this action will now throw an ObjectDisposedException
+Removed a set of exception catch and rethrows to preserve the full callstack to caller. Thanks to Git user 0xceed for prompting ( and sticking with getting us to ) this fix. See: https://github.com/microsoft/PowerPlatform-DataverseServiceClient/pull/248 for details.
+
+
+1.0.23
 Added Async version of ExecuteOrganizationRequest to allow for requests to be made bounded with a custom logging message.
 Update Default settings for "UseWebAPI" in preparation for future work. 
     Note: for Create or Update operations that make extensive use of related entities you may need to reconfigure UseWebAPI to "true". 


### PR DESCRIPTION
Pushing updates from Main development branch. 

Fix by Git user matkov accepted for crash during create when an invalid timespan is passed from a configuration file to the ServiceClient Constructor. See https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/326 for details.
Fixes #326 
Closes #327

Fix by GIT user 0xced accepted for bug in Integrated user security setting,  Code will now properly honor integrated security when attempting to authenticate. See https://github.com/microsoft/PowerPlatform-DataverseServiceClient/pull/324 for details. 
Fixes #324

Fixed a number of places where Async Calls did not have a .ConfigureAwait specification. Thanks to user 0xced for prompting this fix.  Closes #313

Fixed a misleading warning message "Client ID not supplied, using SDK Sample Client ID for this connection" that would be incorrectly shown when ExternalAuthentication type was used. Fixes https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/314, Thanks for your report! 
Fixes #314

Fixed a possible thread contention issue when managing connection context across multiple concurrent threads in the same client.  Git issue: https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/304 Thanks for your report ! 
Fixes #304

Fixed a memory leak when caused by a logger not being cleaned up when a the creation of the ServiceClient fails. Git issue: https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/322
Fixes #322

Fixed issue where calling the IOrganizationService* interfaces after the client has been disposed would throw a NullReferenceException. Taking this action will now throw an ObjectDisposedException

Removed a set of exception catch and rethrows to preserve the full callstack to caller. Thanks to Git user 0xceed for prompting ( and sticking with getting us to ) this fix. See: https://github.com/microsoft/PowerPlatform-DataverseServiceClient/pull/248 for details.
Closes #248

