### PR TITLE
Fix wrong "Client ID not supplied" log with external token management

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/Utils/DataverseConnectionStringProcessor.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/DataverseConnectionStringProcessor.cs
@@ -290,7 +290,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             }
 
             //if the client Id was not passed, use Sample AppID
-            if ((authenticationType != AuthenticationType.AD || authenticationType != AuthenticationType.ExternalTokenManagement) 
+            if (authenticationType != AuthenticationType.AD && authenticationType != AuthenticationType.ExternalTokenManagement
                 && string.IsNullOrWhiteSpace(ClientId))
             {
                 logEntry.Log($"Client ID not supplied, using SDK Sample Client ID for this connection", System.Diagnostics.TraceEventType.Warning);


### PR DESCRIPTION
This looks like a typical wrong application of De Morgan's law