### PR TITLE
Push Update from Main Codebase

### DIFF
--- a/src/Build.Shared.props
+++ b/src/Build.Shared.props
@@ -12,14 +12,16 @@
     <PackageVersion_CrmProxy>4.9.3165-v9.0-weekly-2304.2</PackageVersion_CrmProxy>
     <PackageVersion_CDSServerNuget>4.6.6061-weekly-2108.5</PackageVersion_CDSServerNuget>
     <PackageVersion_Newtonsoft>13.0.1</PackageVersion_Newtonsoft>
-    <PackageVersion_RestClientRuntime>2.3.20</PackageVersion_RestClientRuntime>
+    <PackageVersion_RestClientRuntime>2.3.24</PackageVersion_RestClientRuntime>
     <PackageVersion_XrmSdk>9.0.2.48</PackageVersion_XrmSdk>
     <PackageVersion_Dep_OutlookXrmSdk>9.0.2.34</PackageVersion_Dep_OutlookXrmSdk>
     <PackageVersion_BatchedTelemetry>3.0.8</PackageVersion_BatchedTelemetry>
     <PackageVersion_DataverseClient>0.4.20</PackageVersion_DataverseClient>
     <PackageVersion_CoverletCollector>3.1.0</PackageVersion_CoverletCollector>
     <PackageVersion_Microsoft_Extensions>3.1.8</PackageVersion_Microsoft_Extensions>
-	<PackageVersion_SystemRuntime>6.0.0</PackageVersion_SystemRuntime>
+    <PackageVersion_SystemRuntime>6.0.0</PackageVersion_SystemRuntime>
+    <PackageVersion_SystemTextJsonVersion>7.0.3</PackageVersion_SystemTextJsonVersion>
+    <PackageVersion_SystemTextEncodingsWebVersion>7.0.0</PackageVersion_SystemTextEncodingsWebVersion>
     
     <!-- Test: -->
     <PackageVersion_MicrosoftNETTestSdk>17.5.0</PackageVersion_MicrosoftNETTestSdk>

--- a/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
+++ b/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         /// <summary>
         /// Client or App Id to use.
         /// </summary>
-        private string _clientId;
+        internal string _clientId;
 
         /// <summary>
         /// uri specifying the redirection uri post OAuth auth
@@ -149,7 +149,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
         /// <summary>
         /// Resource to connect to
         /// </summary>
-        private string _resource;
+        internal string _resource;
 
         /// <summary>
         /// cached authority reading from credential manager
@@ -1570,7 +1570,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             
             if (dvService != null)
             {
-                OrganizationVersion = Version.Parse("9.0"); 
+                OrganizationVersion = Version.Parse("9.0.0.0"); 
                 //await GetServerVersion(dvService, _targetInstanceUriToConnectTo).ConfigureAwait(false);
                 //await RefreshInstanceDetails(dvService, _targetInstanceUriToConnectTo).ConfigureAwait(false);
                 // Format the URL for WebAPI service.

--- a/src/GeneralTools/DataverseClient/Client/Microsoft.PowerPlatform.Dataverse.Client.csproj
+++ b/src/GeneralTools/DataverseClient/Client/Microsoft.PowerPlatform.Dataverse.Client.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(PackageVersion_Microsoft_Extensions)" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.3" /> <!-- explict add to deal with CVE-2021-24112  --> 
     <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" /> <!-- explict add to deal with CVE-2022-34716  --> 
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.3" /> <!-- explict add to deal with CVE-2023-29331  --> 
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48'">

--- a/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/ServiceClientTests.cs
+++ b/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/ServiceClientTests.cs
@@ -743,9 +743,8 @@ namespace Client_Core_Tests
 
         [SkippableConnectionTest]
         [Trait("Category", "Live Connect Required")]
-        public void RetrieveSolutionImportResultAsyncTest()
+        public void RetrieveSolutionImportResultAsyncTestWithSyncImport()
         {
-            // Import
             var client = CreateServiceClient();
             if (!Utilities.FeatureVersionMinimums.IsFeatureValidForEnviroment(client._connectionSvc?.OrganizationVersion, Utilities.FeatureVersionMinimums.AllowRetrieveSolutionImportResult))
             {
@@ -754,10 +753,8 @@ namespace Client_Core_Tests
                 return;
             }
 
+            // import solution without async
             client.ImportSolution(Path.Combine("TestData", "TestSolution_1_0_0_1.zip"), out var importId);
-
-            // Wait a little bit because solution might not be immediately available
-            System.Threading.Thread.Sleep(30000);
 
             // Response doesn't include formatted results 
             var resWithoutFormatted = client.RetrieveSolutionImportResultAsync(importId);
@@ -765,6 +762,33 @@ namespace Client_Core_Tests
 
             // Response include formatted results
             var resWithFormatted = client.RetrieveSolutionImportResultAsync(importId, true);
+            resWithFormatted.Should().NotBeNull();
+            resWithFormatted.FormattedResults.Should().NotBeEmpty();
+        }
+
+        [SkippableConnectionTest]
+        [Trait("Category", "Live Connect Required")]
+        public void RetrieveSolutionImportResultAsyncTestWithAsyncImport()
+        {
+            var client = CreateServiceClient();
+            if (!Utilities.FeatureVersionMinimums.IsFeatureValidForEnviroment(client._connectionSvc?.OrganizationVersion, Utilities.FeatureVersionMinimums.AllowRetrieveSolutionImportResult))
+            {
+                // Not supported on this version of Dataverse
+                client._logEntry.Log($"RetrieveSolutionImportResultAsync request is calling RetrieveSolutionImportResult API. This request requires Dataverse version {Utilities.FeatureVersionMinimums.AllowRetrieveSolutionImportResult.ToString()} or above. The current Dataverse version is {client._connectionSvc?.OrganizationVersion}. This request cannot be made", TraceEventType.Warning);
+                return;
+            }
+            // import solution with async
+            client.ImportSolutionAsync(Path.Combine("TestData", "TestSolution_1_0_0_1.zip"), out var asyncImportId);
+
+            // Wait a little bit because solution might not be immediately available
+            System.Threading.Thread.Sleep(30000);
+
+            // Response doesn't include formatted results 
+            var resWithoutFormatted = client.RetrieveSolutionImportResultAsync(asyncImportId);
+            resWithoutFormatted.Should().NotBeNull();
+
+            // Response include formatted results
+            var resWithFormatted = client.RetrieveSolutionImportResultAsync(asyncImportId, true);
             resWithFormatted.Should().NotBeNull();
             resWithFormatted.FormattedResults.Should().NotBeEmpty();
         }

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.Dynamics.nuspec
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.Dynamics.nuspec
@@ -9,8 +9,8 @@
     <projectUrl>https://github.com/microsoft/PowerPlatform-DataverseServiceClient</projectUrl>
     <icon>images\Dataverse.128x128.png</icon>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <description>This package contains the .net core ServiceClient Dynamics Extensions. Used to connect to Microsoft Dataverse. This Package has been authored by the Microsoft Dataverse SDK team.</description>
-    <summary>ServiceClient and supporting libraries for use in building client applications to interact with the Dataverse</summary>
+    <description>This package contains a set of Dynamics 365 specific extensions, used with the Dataverse ServiceClient. This Package has been authored by the Microsoft Dataverse SDK team.</description>
+    <summary>This package contains a set of Dynamics 365 specific extensions, used with the Dataverse ServiceClient.</summary>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>Dynamics CommonDataService CDS PowerApps PowerPlatform ServiceClient Dataverse</tags>
     <dependencies>

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
@@ -7,6 +7,14 @@ Notice:
     Note: Only AD on FullFramework, OAuth, Certificate, ClientSecret Authentication types are supported at this time.
 
 ++CURRENTRELEASEID++
+Refactored CurrentAccessToken property to avoid async call. 
+Fix for min version of default client, pre-connection so it is recognized by features that require 9.0 or greater.
+Fix for notification of unsupported features when not 'breaking' to alert as 'warnings' in log vs information. 
+Dependency changes:
+    Microsoft.Rest.Client moved to 2.3.24 due to CVE-2022-26907.
+
+
+1.1.9: 
 REMOVED .net 3.1 and .net 5 support as they are out of support frameworks. 
 Added new DiscoverOnlineOrganizationsAsync which supports CancellationToken
 Added new RetrieveSolutionImportResultAsync for retrieving solution import result from Dataverse

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.nuspec
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.nuspec
@@ -21,7 +21,7 @@
         <dependency id="Microsoft.Extensions.Caching.Memory" version="3.1.8" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Identity.Client" version="4.35.1" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Identity.Client.Extensions.Msal" version="2.18.9" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.24" exclude="Build,Analyzers" />
         <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.7" exclude="Build,Analyzers" />
       </group>
@@ -32,7 +32,7 @@
         <dependency id="Microsoft.Extensions.Caching.Memory" version="3.1.8" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Identity.Client" version="4.35.1" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Identity.Client.Extensions.Msal" version="2.18.9" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.24" exclude="Build,Analyzers" />
         <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.7" exclude="Build,Analyzers" />
       </group>
@@ -43,7 +43,7 @@
         <dependency id="Microsoft.Extensions.Caching.Memory" version="3.1.8" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Identity.Client" version="4.35.1" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Identity.Client.Extensions.Msal" version="2.18.9" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.24" exclude="Build,Analyzers" />
         <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.7" exclude="Build,Analyzers" />
       </group>
@@ -67,7 +67,7 @@
         <dependency id="Microsoft.Extensions.Caching.Memory" version="3.1.8" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Identity.Client" version="4.35.1" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Identity.Client.Extensions.Msal" version="2.18.9" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.24" exclude="Build,Analyzers" />
         <dependency id="Microsoft.VisualBasic" version="10.3.0" exclude="Build,Analyzers" />
         <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Configuration.ConfigurationManager" version="4.7.0" exclude="Build,Analyzers" />
@@ -75,6 +75,7 @@
         <dependency id="System.Security.Cryptography.Algorithms" version="4.3.1" exclude="Build,Analyzers" />
         <dependency id="System.Security.Cryptography.ProtectedData" version="4.7.0" exclude="Build,Analyzers" />
         <dependency id="System.Security.Cryptography.Xml" version="6.0.1" exclude="Build,Analyzers" /> <!-- Added for CVE-2022-34716 and CVE-2021-24112 -->
+        <dependency id="System.Security.Cryptography.Pkcs" version="6.0.3" exclude="Build,Analyzers" /> <!-- Added for CVE-2023-29331 -->
         <dependency id="System.Drawing.Common" version="5.0.3" exclude="Build,Analyzers"/> <!-- explict add to deal with CVE-2021-24112  --> 
       </group>      
     </dependencies>


### PR DESCRIPTION
Refactored CurrentAccessToken property to avoid async call.
Fix for min version of default client, pre-connection so it is recognized by features that require 9.0 or greater. fix #381 381
Fix for notification of unsupported features when not 'breaking' to alert as 'warnings' in log vs information.
Dependency changes:
   Microsoft.Rest.Client moved to 2.3.24 due to CVE-2022-26907.