### PR TITLE
Resync from mainline. 

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/Auth/TokenCache/FileBackedTokenCacheHints.cs
+++ b/src/GeneralTools/DataverseClient/Client/Auth/TokenCache/FileBackedTokenCacheHints.cs
@@ -37,6 +37,13 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth.TokenCache
             if (AppDomain.CurrentDomain != null)
             {
                 hostName = Path.GetFileNameWithoutExtension(AppDomain.CurrentDomain.FriendlyName);
+                if (hostName.IndexOfAny(Path.GetInvalidFileNameChars()) < 0)
+                {
+                    foreach (var c in Path.GetInvalidFileNameChars())
+                    {
+                        hostName = hostName.Replace(c, '_');
+                    }
+                }
             }
             string hostVersion = Environs.XrmSdkFileVersion;
             string companyName = typeof(OrganizationDetail).Assembly.GetCustomAttribute<AssemblyCompanyAttribute>().Company;

--- a/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
+++ b/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
@@ -1750,6 +1750,9 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                         _OrgDetail.UniqueName = resp.Detail.UniqueName;
                         _OrgDetail.UrlName = resp.Detail.UrlName;
                         _OrgDetail.DatacenterId = resp.Detail.DatacenterId;
+                        _OrgDetail.SchemaType = resp.Detail.SchemaType;
+                        _OrgDetail.OrganizationType = resp.Detail.OrganizationType;
+
                     }
                     _organization = _OrgDetail.UniqueName;
 
@@ -3007,6 +3010,8 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                     d.EnvironmentId = !string.IsNullOrEmpty(inst.EnvironmentId) ? inst.EnvironmentId : string.Empty;
                     d.Geo = !string.IsNullOrEmpty(inst.Region) ? inst.Region : string.Empty;
                     d.TenantId = !string.IsNullOrEmpty(inst.TenantId) ? inst.TenantId : string.Empty;
+                    d.SchemaType = !string.IsNullOrEmpty(inst.SchemaType) ? inst.SchemaType : string.Empty;
+                    d.OrganizationType = (Xrm.Sdk.Organization.OrganizationType)Enum.Parse(typeof(Xrm.Sdk.Organization.OrganizationType), inst.OrganizationType.ToString());
                     System.Reflection.PropertyInfo proInfo = d.GetType().GetProperty("Endpoints");
                     if (proInfo != null)
                     {

--- a/src/GeneralTools/DataverseClient/Client/Model/GlobalDiscoveryModel.cs
+++ b/src/GeneralTools/DataverseClient/Client/Model/GlobalDiscoveryModel.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -49,7 +49,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Model
 		public DateTime TrialExpirationDate { get; set; }
 		[JsonProperty(PropertyName = "Purpose")]
 		public string Purpose { get; set; }
-
-
-	}
+        [JsonProperty(PropertyName = "SchemaType")]
+        public string SchemaType { get; set; }
+    }
 }

--- a/src/GeneralTools/DataverseClient/Client/Utils/Utils.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/Utils.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                     using (DiscoveryServers discoSvcs = new DiscoveryServers())
                     {
                         return discoSvcs.GetServerByShortName(OnlineRegon);
-                    };
+                    }
                 }
             }
             return null;

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
@@ -9,6 +9,7 @@ Notice:
 ++CURRENTRELEASEID++
 Updated Core SDK
 Added new properties to Organization detail to report Schema Type and Deployment Type. 
+Fixed bug in creating file to user token cache when host name contains invalid characters. Fixes #406
 Dependency changes:
     System.Text.Json moved to 7.0.3
     Microsoft.Identity.Client moved to 4.56.0


### PR DESCRIPTION
This pull request to the `DataverseClient` project includes a variety of bug fixes and improvements. The most important changes include fixing a bug related to token cache file creation and adding two new properties to the `OrganizationDetail` and `DiscoveryServer` objects.

Bug fixes:

* <a href="diffhunk://#diff-d6ba5b18ddf97fabea3bac73835d8c16d233aa56df9f8a44a233383e5cc09d56R40-R46">`src/GeneralTools/DataverseClient/Client/Auth/TokenCache/FileBackedTokenCacheHints.cs`</a>: Fixed a bug where the token cache file couldn't be created if the host name contained invalid characters by adding a check to replace invalid characters with underscores.
* <a href="diffhunk://#diff-5bbf87934340f1d38d356bc834af67cbaf6d79d93aaee952461c95b71c3d855bR12">`src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt`</a>: Fixed a bug related to token cache file creation and updated dependency versions for System.Text.Json and Microsoft.Identity.Client.

New features:

* <a href="diffhunk://#diff-90d50c09b68c1befad68aa0f6d1abe55c38a08dd5bfcbfe0bc0799166b2781a4R1753-R1755">`src/GeneralTools/DataverseClient/Client/ConnectionService.cs`</a>: Added two new properties, `SchemaType` and `OrganizationType`, to both the `OrganizationDetail` and `DiscoveryServer` objects. <a href="diffhunk://#diff-90d50c09b68c1befad68aa0f6d1abe55c38a08dd5bfcbfe0bc0799166b2781a4R1753-R1755">[1]</a> <a href="diffhunk://#diff-90d50c09b68c1befad68aa0f6d1abe55c38a08dd5bfcbfe0bc0799166b2781a4R3013-R3014">[2]</a>
* <a href="diffhunk://#diff-58eb843da934944e4ec911b30e85cfa51f8bda08dd065a2f40a7d947ac974362L1-R1">`src/GeneralTools/DataverseClient/Client/Model/GlobalDiscoveryModel.cs`</a>: Added a new property to the `GlobalDiscoveryInstanceModel` class and updated the using statements in the `GlobalDiscoveryModel` class. <a href="diffhunk://#diff-58eb843da934944e4ec911b30e85cfa51f8bda08dd065a2f40a7d947ac974362L1-R1">[1]</a> <a href="diffhunk://#diff-58eb843da934944e4ec911b30e85cfa51f8bda08dd065a2f40a7d947ac974362L52-R53">[2]</a>

Code improvements:
Fix to include #384 
Fix to include #406 
* <a href="diffhunk://#diff-05764c823ebb0fb7f3da91d6b25722d6494c49a78e10ed8f1e0c08e9883f33e1L46-R46">`src/GeneralTools/DataverseClient/Client/Utils/Utils.cs`</a>: Removed an unnecessary semicolon in the `GetDiscoveryServerByUri` method.