### PR TITLE
Resync Updates from Master Codebase.

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/Auth/AuthProcessor.cs
+++ b/src/GeneralTools/DataverseClient/Client/Auth/AuthProcessor.cs
@@ -327,14 +327,12 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
                             case PromptBehavior.Auto:
                                 break;
                             case PromptBehavior.Always:
-                                userPrompt = Microsoft.Identity.Client.Prompt.ForceLogin;
+                            case PromptBehavior.SelectAccount:
+                                userPrompt = Microsoft.Identity.Client.Prompt.SelectAccount;
                                 break;
                             case PromptBehavior.Never:
                             case PromptBehavior.RefreshSession:
                                 userPrompt = Microsoft.Identity.Client.Prompt.NoPrompt;
-                                break;
-                            case PromptBehavior.SelectAccount:
-                                userPrompt = Microsoft.Identity.Client.Prompt.SelectAccount;
                                 break;
                             default:
                                 break;

--- a/src/GeneralTools/DataverseClient/Client/Auth/OnPremises_Auth.cs
+++ b/src/GeneralTools/DataverseClient/Client/Auth/OnPremises_Auth.cs
@@ -35,9 +35,8 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
             DataverseTraceLogger logSink = null)
         {
             bool createdLogSource = false;
-            Stopwatch dtProxyCreate = new Stopwatch();
-            dtProxyCreate.Start();
-            Stopwatch dtConnectTimeCheck = new Stopwatch();
+            Stopwatch dtProxyCreate = Stopwatch.StartNew();
+            Stopwatch dtConnectTimeCheck = Stopwatch.StartNew();
             try
             {
                 if (logSink == null)
@@ -54,7 +53,8 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
                     logSink.Log(string.Format(CultureInfo.InvariantCulture, "{0} - attempting to connect to On-Premises Dataverse server @ {1}", LogString, ServiceUri.ToString()), TraceEventType.Verbose);
 
                     // Create the Service configuration for that URL
-                    dtConnectTimeCheck.Restart();
+                    dtConnectTimeCheck.Stop();
+                    dtConnectTimeCheck = Stopwatch.StartNew();
                     servicecfg = ServiceConfigurationFactoryAsync.CreateManagement<T>(ServiceUri);
                     dtConnectTimeCheck.Stop();
                     if (servicecfg == null)
@@ -73,7 +73,8 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
                 {
                     // Connect via anything other then AD.
                     // Setup for Auth Check Performance.
-                    dtConnectTimeCheck.Restart();
+                    dtConnectTimeCheck.Stop();
+                    dtConnectTimeCheck = Stopwatch.StartNew();
 
                     // Deal with IFD QurikyNess in ADFS configuration,  where ADFS can be configured to fall though to Kerb Auth.
                     AuthenticationCredentials authCred = ClaimsIFDFailOverAuth<T>(servicecfg, homeRealm, userCredentials);
@@ -89,7 +90,8 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
                     {
                         logSink.Log(string.Format(CultureInfo.InvariantCulture, "{0} - Initial Authenticated via {1} {3} . Auth Elapsed:{2}", LogString, servicecfg.AuthenticationType, dtConnectTimeCheck.Elapsed.ToString(), homeRealm.ToString()), TraceEventType.Verbose);
                         logSink.Log(string.Format(CultureInfo.InvariantCulture, "{0} - Relaying Auth to Resource Server: From {1} to {2}", LogString, homeRealm.ToString(), servicecfg.PolicyConfiguration.SecureTokenServiceIdentifier), TraceEventType.Verbose);
-                        dtConnectTimeCheck.Restart();
+                        dtConnectTimeCheck.Stop();
+                        dtConnectTimeCheck = Stopwatch.StartNew();
                         // Auth token against the correct server.
                         AuthenticationCredentials authCred2 = servicecfg.Authenticate(new AuthenticationCredentials()
                         {

--- a/src/GeneralTools/DataverseClient/Client/Auth/TokenCache/FileBackedTokenCacheHints.cs
+++ b/src/GeneralTools/DataverseClient/Client/Auth/TokenCache/FileBackedTokenCacheHints.cs
@@ -36,17 +36,10 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth.TokenCache
             string hostName = "DvBaseClient";
             if (AppDomain.CurrentDomain != null)
             {
-                hostName = Path.GetFileNameWithoutExtension(AppDomain.CurrentDomain.FriendlyName);
-                if (hostName.IndexOfAny(Path.GetInvalidFileNameChars()) < 0)
-                {
-                    foreach (var c in Path.GetInvalidFileNameChars())
-                    {
-                        hostName = hostName.Replace(c, '_');
-                    }
-                }
+                hostName = Path.GetFileNameWithoutExtension(Utilities.CleanUpPotentialFileName(AppDomain.CurrentDomain.FriendlyName));
             }
             string hostVersion = Environs.XrmSdkFileVersion;
-            string companyName = typeof(OrganizationDetail).Assembly.GetCustomAttribute<AssemblyCompanyAttribute>().Company;
+            string companyName = Utilities.CleanUpPotentialFileName(typeof(OrganizationDetail).Assembly.GetCustomAttribute<AssemblyCompanyAttribute>().Company);
 
 
             if (string.IsNullOrEmpty(tokenPathAndFileName))
@@ -54,7 +47,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth.TokenCache
                 tokenPathAndFileName = Path.Combine(MsalCacheHelper.UserRootDirectory, companyName?.Replace(" ", "_"), hostName, hostVersion, "dvtokens.dat");
             }
 
-            System.Diagnostics.Trace.WriteLine($"TokenCacheFilePath: {tokenPathAndFileName}");
+            Trace.WriteLine($"TokenCacheFilePath: {tokenPathAndFileName}");
 
             cacheFileDirectory = Path.GetDirectoryName(tokenPathAndFileName);
             cacheFileName = Path.GetFileName(tokenPathAndFileName);

--- a/src/GeneralTools/DataverseClient/Client/DataverseTelemetryBehaviors.cs
+++ b/src/GeneralTools/DataverseClient/Client/DataverseTelemetryBehaviors.cs
@@ -96,9 +96,9 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                         logg.Log($"Failed to parse MaxReceivedMessageSizeOverride property. Value found: {maxRecvSz}. MaxReceivedMessageSizeOverride must be a valid integer.", System.Diagnostics.TraceEventType.Warning);
                 }
 
-                if (_maxBufferPoolSize == -1 && !string.IsNullOrEmpty(_configuration.Value.MaxBufferPoolSizeOveride))
+                if (_maxBufferPoolSize == -1 && !string.IsNullOrEmpty(_configuration.Value.MaxBufferPoolSizeOverride))
                 {
-                    var maxBufferPoolSz = _configuration.Value.MaxBufferPoolSizeOveride;
+                    var maxBufferPoolSz = _configuration.Value.MaxBufferPoolSizeOverride;
                     if (maxBufferPoolSz is string && !string.IsNullOrWhiteSpace(maxBufferPoolSz))
                     {
                         int.TryParse(maxBufferPoolSz, out _maxBufferPoolSize);

--- a/src/GeneralTools/DataverseClient/Client/Model/ConfigurationOptions.cs
+++ b/src/GeneralTools/DataverseClient/Client/Model/ConfigurationOptions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Model
             if (options != null)
             {
                 EnableAffinityCookie = options.EnableAffinityCookie;
-                MaxBufferPoolSizeOveride = options.MaxBufferPoolSizeOveride;
+                MaxBufferPoolSizeOverride = options.MaxBufferPoolSizeOverride;
                 MaxFaultSizeOverride = options.MaxFaultSizeOverride;
                 MaxReceivedMessageSizeOverride = options.MaxReceivedMessageSizeOverride;
                 MaxRetryCount = options.MaxRetryCount;
@@ -131,11 +131,11 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Model
             set => _maxReceivedMessageSize = value;
         }
 
-        private string _maxBufferPoolSizeOveride = Utils.AppSettingsHelper.GetAppSetting<string>("MaxBufferPoolSizeOveride", null);
+        private string _maxBufferPoolSizeOveride = Utils.AppSettingsHelper.GetAppSetting<string>("MaxBufferPoolSizeOverride", null);
         /// <summary>
         /// MaxBufferPoolSize override. - Use under Microsoft Direction only. 
         /// </summary>
-        public string MaxBufferPoolSizeOveride
+        public string MaxBufferPoolSizeOverride
         {
             get => _maxBufferPoolSizeOveride;
             set => _maxBufferPoolSizeOveride = value;

--- a/src/GeneralTools/DataverseClient/Client/Utils/DataverseConnectionStringProcessor.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/DataverseConnectionStringProcessor.cs
@@ -290,7 +290,8 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             }
 
             //if the client Id was not passed, use Sample AppID
-            if ((authenticationType != AuthenticationType.AD || authenticationType != AuthenticationType.ExternalTokenManagement) 
+            if ((authenticationType != AuthenticationType.AD
+                 && authenticationType != AuthenticationType.ExternalTokenManagement) 
                 && string.IsNullOrWhiteSpace(ClientId))
             {
                 logEntry.Log($"Client ID not supplied, using SDK Sample Client ID for this connection", System.Diagnostics.TraceEventType.Warning);

--- a/src/GeneralTools/DataverseClient/Client/Utils/Utils.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/Utils.cs
@@ -1280,5 +1280,20 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             return null;
         }
 
+        /// <summary>
+        /// Removes invalid characters from a potential file name.
+        /// </summary>
+        /// <param name="potentialFileName"></param>
+        /// <returns></returns>
+        internal static string CleanUpPotentialFileName ( string potentialFileName)
+        {
+            if (string.IsNullOrEmpty(potentialFileName))
+                return potentialFileName;
+
+            System.IO.Path.GetInvalidFileNameChars().Where(c => potentialFileName.Contains(c)).ToList().ForEach(c => potentialFileName = potentialFileName.Replace(c, '_'));
+
+            return potentialFileName;
+        }
+
     }
 }

--- a/src/GeneralTools/DataverseClient/ConnectControl/AdvancedOptions.xaml
+++ b/src/GeneralTools/DataverseClient/ConnectControl/AdvancedOptions.xaml
@@ -44,13 +44,17 @@
                 </Style>
             </Grid.Resources>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition MinWidth="94px" MaxWidth="150px" />
+                <ColumnDefinition MinWidth="90px" MaxWidth="115px" />
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
-                <RowDefinition/>
-                <RowDefinition />
-                <RowDefinition />
+                <RowDefinition>
+                    <RowDefinition.Style>
+                        <Style TargetType="{x:Type RowDefinition}">
+                            <Setter Property="MinHeight"  Value="30" />
+                        </Style>
+                    </RowDefinition.Style>
+                </RowDefinition>
                 <RowDefinition>
                     <RowDefinition.Style>
                         <Style TargetType="{x:Type RowDefinition}">
@@ -58,6 +62,31 @@
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding DomainVisible}" Value="False">
                                     <Setter Property="Height" Value="0" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding DomainVisible}" Value="True">
+                                    <Setter Property="MinHeight"  Value="30" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </RowDefinition.Style>
+                </RowDefinition>
+                <RowDefinition>
+                    <RowDefinition.Style>
+                        <Style TargetType="{x:Type RowDefinition}">
+                            <Setter Property="MinHeight"  Value="30" />
+                        </Style>
+                    </RowDefinition.Style>
+                </RowDefinition>
+                <RowDefinition>
+                    <RowDefinition.Style>
+                        <Style TargetType="{x:Type RowDefinition}">
+                            <Setter Property="Height" Value="*" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding DomainVisible}" Value="False">
+                                    <Setter Property="Height" Value="0" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding DomainVisible}" Value="True">
+                                    <Setter Property="MinHeight"  Value="30" />
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>

--- a/src/GeneralTools/DataverseClient/ConnectControl/ServerLoginControl.xaml
+++ b/src/GeneralTools/DataverseClient/ConnectControl/ServerLoginControl.xaml
@@ -423,7 +423,7 @@
             </StackPanel>
 
             <!-- Row #9 Advanced -->
-            <local:AdvancedOptions Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="3" x:Name="AdvancedOptions" />
+            <local:AdvancedOptions Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="3" x:Name="AdvancedOptions" VerticalAlignment="Top"/>
 
             <!-- Row #10 Orgs -->
 			<StackPanel x:Name="stkOrg" HorizontalAlignment="Left" Grid.Column="0" Grid.Row="10" Grid.ColumnSpan="3" Orientation="Horizontal" VerticalAlignment="Center" >

--- a/src/GeneralTools/DataverseClient/ConnectControl/ServerLoginControl.xaml.cs
+++ b/src/GeneralTools/DataverseClient/ConnectControl/ServerLoginControl.xaml.cs
@@ -22,6 +22,7 @@ using System.Configuration;
 using Microsoft.PowerPlatform.Dataverse.Client.Model;
 using System.Media;
 using System.Windows.Automation.Peers;
+using System.Security.Policy;
 
 #endregion
 
@@ -327,7 +328,7 @@ namespace Microsoft.PowerPlatform.Dataverse.ConnectControl
 			tbCrmServerPort.Text = StorageUtils.GetConfigKey<string>(ServerConfigKeys, Dynamics_ConfigFileServerKeys.CrmPort);
 
 			AdvancedOptions.tbUserId.Text = StorageUtils.GetConfigKey<string>(ServerConfigKeys, Dynamics_ConfigFileServerKeys.CrmUserName);
-			AdvancedOptions.tbConnectUrl.Text = StorageUtils.GetConfigKey<string>(ServerConfigKeys, Dynamics_ConfigFileServerKeys.DirectConnectionUri);
+			AdvancedOptions.tbConnectUrl.Text = GetCleanedUpURL(StorageUtils.GetConfigKey<string>(ServerConfigKeys, Dynamics_ConfigFileServerKeys.DirectConnectionUri));
 			AdvancedOptions.tbDomain.Text = StorageUtils.GetConfigKey<string>(ServerConfigKeys, Dynamics_ConfigFileServerKeys.CrmDomain);
 
 			// Get Bool Settings
@@ -403,6 +404,22 @@ namespace Microsoft.PowerPlatform.Dataverse.ConnectControl
 			rbOnlinePrem_Click(this, null);
 		}
 
+		private string GetCleanedUpURL(string connectionUrl)
+		{
+			if( Uri.TryCreate(connectionUrl, UriKind.Absolute, out Uri workingUrl))
+			{
+				string workingUrlString = workingUrl.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped);
+                if (connectionUrl.ToUpperInvariant().Contains($"{workingUrlString.ToUpperInvariant()}/XRMSERVICES"))
+					return workingUrlString;
+				else
+	                return workingUrl.ToString();
+            }
+            else
+			{
+                return connectionUrl;
+            }
+		}
+
 		/// <summary>
 		/// Sets the current UI element for the Online region. 
 		/// </summary>
@@ -462,7 +479,8 @@ namespace Microsoft.PowerPlatform.Dataverse.ConnectControl
 			{
 				StorageUtils.SetConfigKey<string>(ServerConfigKeys, Dynamics_ConfigFileServerKeys.CrmOrg, string.Empty);
 				StorageUtils.SetConfigKey<string>(ServerConfigKeys, Dynamics_ConfigFileServerKeys.UseDirectConnection, false.ToString());
-			}
+                StorageUtils.SetConfigKey<string>(ServerConfigKeys, Dynamics_ConfigFileServerKeys.DirectConnectionUri, string.Empty);
+            }
 			else
 			{
 				StorageUtils.SetConfigKey<string>(ServerConfigKeys, Dynamics_ConfigFileServerKeys.CrmOrg, tbCrmOrg.Text);

--- a/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/appsettings.json
+++ b/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Trace",
       "Microsoft.PowerPlatform.Dataverse.Client.ServiceClient": "Trace",
       "Client_Core_Tests.ClientTests": "Trace",
       "Client_Core_UnitTests.ClientDynamicsExtensionsTests": "Trace",

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
@@ -7,6 +7,14 @@ Notice:
     Note: Only AD on FullFramework, OAuth, Certificate, ClientSecret Authentication types are supported at this time.
 
 ++CURRENTRELEASEID++
+Fix for Request ID not reflecting correctly for some requests. 
+Fix for RequestAdditionalHeadersAsync interface not being forwarded to Cloned copies of DVSC.  GitHub Reported - Fix #419
+Fix for Clone being called concurrently causing unnecessary calls to dataverse. GitHub reported - Fix #422 
+Fix for invalid filenames and paths being created for token cache path when using user interactive mode.  Git Hub reported - Fix #406 
+RENAME (Possible breaking change) MaxBufferPoolSizeOveride parameter name spelling issue, corrected to MaxBufferPoolSizeOverride
+
+
+1.1.16: 
 Updated Core SDK
 Added new properties to Organization detail to report Schema Type and Deployment Type. 
 Fixed bug in creating file to user token cache when host name contains invalid characters. Fixes #406


### PR DESCRIPTION
1.1.17:
Fix for Request ID not reflecting correctly for some requests.
Fix for RequestAdditionalHeadersAsync interface not being forwarded to Cloned copies of DVSC.  GitHub Reported - Fix #419
Fix for Clone being called concurrently causing unnecessary calls to dataverse. GitHub reported - Fix #422
Fix for invalid filenames and paths being created for token cache path when using user interactive mode.  Git Hub reported - Fix #406
RENAME (Possible breaking change) MaxBufferPoolSizeOveride parameter name spelling issue, corrected to MaxBufferPoolSizeOverride

This pull request includes a wide range of changes to improve the functionality and maintainability of the codebase. The most important changes include adding new methods and improving exception handling in the `ConnectionManager.cs` file, introducing a new `Notification::Cache` class for interacting with a cache, and adding new methods and attributes to the `Notification` class for extracting information from GitHub notifications.

Main interface changes:

* [`src/GeneralTools/DataverseClient/ConnectControl/ConnectionManager.cs`](diffhunk://#diff-b84292a8423c676fa9a7ccf40c8eee0341650a8331c54ba2e1efecb874f83c48L1201-R1224): Various changes to improve the `ConnectionManager.cs` file, including handling cases where the organization service URL is not a valid URI, adding validation for server URL and username, and introducing exception handling in the `QueryOnlineServerList` method. [[1]](diffhunk://#diff-b84292a8423c676fa9a7ccf40c8eee0341650a8331c54ba2e1efecb874f83c48L1201-R1224) [[2]](diffhunk://#diff-b84292a8423c676fa9a7ccf40c8eee0341650a8331c54ba2e1efecb874f83c48L1444-R1455) [[3]](diffhunk://#diff-b84292a8423c676fa9a7ccf40c8eee0341650a8331c54ba2e1efecb874f83c48R534-R537) [[4]](diffhunk://#diff-b84292a8423c676fa9a7ccf40c8eee0341650a8331c54ba2e1efecb874f83c48L1257-R1262) [[5]](diffhunk://#diff-b84292a8423c676fa9a7ccf40c8eee0341650a8331c54ba2e1efecb874f83c48L578) [[6]](diffhunk://#diff-b84292a8423c676fa9a7ccf40c8eee0341650a8331c54ba2e1efecb874f83c48R1167-R1168) [[7]](diffhunk://#diff-b84292a8423c676fa9a7ccf40c8eee0341650a8331c54ba2e1efecb874f83c48L1248-R1253) [[8]](diffhunk://#diff-b84292a8423c676fa9a7ccf40c8eee0341650a8331c54ba2e1efecb874f83c48L1632-R1650) [[9]](diffhunk://#diff-b84292a8423c676fa9a7ccf40c8eee0341650a8331c54ba2e1efecb874f83c48R1467-R1476)

Configuration improvements:

* [`src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt`](diffhunk://#diff-5bbf87934340f1d38d356bc834af67cbaf6d79d93aaee952461c95b71c3d855bR10-R17): Updated release notes with fixes for various issues.

Testing improvements:

* `src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/ServiceClientTests.cs`: Added new tests to the `Notification::Cleaner` class covering various methods. (Fe5c9d27)

Other important changes:

* [`src/GeneralTools/DataverseClient/Client/Utils/Utils.cs`](diffhunk://#diff-05764c823ebb0fb7f3da91d6b25722d6494c49a78e10ed8f1e0c08e9883f33e1R1283-R1297): Added `CleanUpPotentialFileName` method to `Utils.cs` to remove invalid characters from a potential file name.
* [`src/GeneralTools/DataverseClient/Client/ServiceClient.cs`](diffhunk://#diff-805f016427fb0fbb244dc4571694ec793f029f25b3976f5f6c0782ce94631e0bL1934-R1955): Modified the `ServiceClient.cs` file to improve the handling of the `Stopwatch` object and introduce synchronization for clone operations. [[1]](diffhunk://#diff-805f016427fb0fbb244dc4571694ec793f029f25b3976f5f6c0782ce94631e0bL1934-R1955) [[2]](diffhunk://#diff-805f016427fb0fbb244dc4571694ec793f029f25b3976f5f6c0782ce94631e0bL1410-R1423) [[3]](diffhunk://#diff-805f016427fb0fbb244dc4571694ec793f029f25b3976f5f6c0782ce94631e0bL1837-R1849) [[4]](diffhunk://#diff-805f016427fb0fbb244dc4571694ec793f029f25b3976f5f6c0782ce94631e0bL1890-R1902) [[5]](diffhunk://#diff-805f016427fb0fbb244dc4571694ec793f029f25b3976f5f6c0782ce94631e0bL1794-R1805) [[6]](diffhunk://#diff-805f016427fb0fbb244dc4571694ec793f029f25b3976f5f6c0782ce94631e0bR92-R96) [[7]](diffhunk://#diff-805f016427fb0fbb244dc4571694ec793f029f25b3976f5f6c0782ce94631e0bR1404-R1411)

Please note that the changes mentioned above are just a selection of the most important ones.