### PR TITLE
07102024 release - Updates to RequestBuilder Shipping Connector

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/Auth/AuthProcessor.cs
+++ b/src/GeneralTools/DataverseClient/Client/Auth/AuthProcessor.cs
@@ -70,6 +70,9 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
                     createdLogSource = true;
                     logSink = new DataverseTraceLogger();
                 }
+                
+                // Set the logger in the MSAL Logger
+                MSALLoggerCallBack mSALLogger = new MSALLoggerCallBack(logSink);
 
                 string Authority = string.Empty;
                 string Resource = string.Empty;
@@ -139,7 +142,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
                         .WithAuthority(Authority)
                         .WithLegacyCacheCompatibility(false)
                         .WithHttpClientFactory(new MSALHttpClientFactory())
-                        .WithLogging(MSALLoggerCallBack.Log);
+                        .WithLogging(mSALLogger.Log);
                     }
 
                     // initialization of memory cache if its not already initialized.
@@ -189,7 +192,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
                             })
                         .WithAuthority(Authority)
                         .WithLegacyCacheCompatibility(false)
-                        .WithLogging(MSALLoggerCallBack.Log);
+                        .WithLogging(mSALLogger.Log);
 
                         pApp = cApp.Build();
 
@@ -300,9 +303,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Auth
                     }
                     else
                     {
-#pragma warning disable CS0618 // Type or member is obsolete
-                        _authenticationResult = await publicAppClient.AcquireTokenByUsernamePassword(scopes, clientCredentials.UserName.UserName, ServiceClient.MakeSecureString(clientCredentials.UserName.Password)).ExecuteAsync().ConfigureAwait(false);
-#pragma warning restore CS0618 // Type or member is obsolete
+                        _authenticationResult = await publicAppClient.AcquireTokenByUsernamePassword(scopes, clientCredentials.UserName.UserName, clientCredentials.UserName.Password).ExecuteAsync().ConfigureAwait(false);
                     }
                 }
                 else

--- a/src/GeneralTools/DataverseClient/Client/Builder/AbstractClientRequestBuilder.cs
+++ b/src/GeneralTools/DataverseClient/Client/Builder/AbstractClientRequestBuilder.cs
@@ -133,6 +133,16 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Builder
                 parameters.Add(RequestBinderUtil.HEADERLIST, new Dictionary<string,string>(_headers));
             }
 
+            if (_crmUserId != null && _crmUserId != Guid.Empty)
+            {
+                parameters.Add(RequestHeaders.CALLER_OBJECT_ID_HTTP_HEADER, _crmUserId.Value);
+            }
+
+            if (_aadOidId != null && _aadOidId != Guid.Empty)
+            {
+                parameters.Add(RequestHeaders.AAD_CALLER_OBJECT_ID_HTTP_HEADER, _aadOidId.Value);
+            }
+
             request.Parameters.AddRange(parameters);
 
             // Clear in case this is reused.             

--- a/src/GeneralTools/DataverseClient/Client/ServiceClient.cs
+++ b/src/GeneralTools/DataverseClient/Client/ServiceClient.cs
@@ -2039,11 +2039,10 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                     OrgEx.Detail.ErrorCode == ErrorCodes.ThrottlingTimeExceededError ||
                     OrgEx.Detail.ErrorCode == ErrorCodes.ThrottlingConcurrencyLimitExceededError)
                 {
-                    // Error was raised by a instance throttle trigger.
-                    if (OrgEx.Detail.ErrorCode == ErrorCodes.ThrottlingBurstRequestLimitExceededError)
-                    {
-                        // Use Retry-After delay when specified
-                        _retryPauseTimeRunning = (TimeSpan)OrgEx.Detail.ErrorDetails["Retry-After"];
+                     // Use Retry-After delay when specified
+                    if (OrgEx.Detail.ErrorDetails.TryGetValue("Retry-After", out var retryAfter) && retryAfter is TimeSpan retryAsTimeSpan)
+                    { 
+                         _retryPauseTimeRunning = retryAsTimeSpan;
                     }
                     else
                     {

--- a/src/GeneralTools/DataverseClient/Client/Utils/MSALLoggerCallBack.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/MSALLoggerCallBack.cs
@@ -8,15 +8,22 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Utils
     /// <summary>
     /// This class will be used to support hooking into MSAL Call back logic.
     /// </summary>
-    internal static class MSALLoggerCallBack
+    internal class MSALLoggerCallBack
     {
-        private static DataverseTraceLogger _logEntry;
+
+        public DataverseTraceLogger LogSink { get; set; } = null;
 
         /// <summary>
         /// Enabled PII logging for this connection.
         /// if this flag is set, it will override the value from app config.
         /// </summary>
-        public static bool? EnabledPIILogging { get; set; } = null;
+        public bool? EnabledPIILogging { get; set; } = null;
+
+        public MSALLoggerCallBack(DataverseTraceLogger logSink = null, bool? enabledPIILogging = null)
+        {
+            LogSink = logSink;
+            EnabledPIILogging = enabledPIILogging;
+        }
 
         /// <summary>
         ///
@@ -24,15 +31,19 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Utils
         /// <param name="level"></param>
         /// <param name="message"></param>
         /// <param name="containsPii"></param>
-        static public void Log(LogLevel level, string message, bool containsPii)
+        public void Log(LogLevel level, string message, bool containsPii)
         {
-            if (_logEntry == null)
-                _logEntry = new DataverseTraceLogger(typeof(LogCallback).Assembly.GetName().Name); // set up logging client.
+            bool createdLogSource = false;
+            if (LogSink == null)
+            {
+                createdLogSource = true;
+                LogSink = new DataverseTraceLogger(typeof(LogCallback).Assembly.GetName().Name); // set up logging client.
+            }
 
             if (!EnabledPIILogging.HasValue)
             {
                 EnabledPIILogging = ClientServiceProviders.Instance.GetService<IOptions<ConfigurationOptions>>().Value.MSALEnabledLogPII;
-                _logEntry.Log($"Setting MSAL PII Logging Feature to {EnabledPIILogging.Value}", System.Diagnostics.TraceEventType.Information);
+                LogSink.Log($"Setting MSAL PII Logging Feature to {EnabledPIILogging.Value}", System.Diagnostics.TraceEventType.Information);
             }
 
             if (containsPii && !EnabledPIILogging.Value)
@@ -41,24 +52,29 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Utils
             }
 
             // Add (PII) prefix to messages that have PII in them per AAD Message alert.
-            message = containsPii ? $"(PII){message}" : message;
+            message = containsPii ? $"(PII){message}" : message; 
 
             switch (level)
             {
                 case LogLevel.Info:
-                    _logEntry.Log(message, System.Diagnostics.TraceEventType.Information);
+                    LogSink.Log(message, System.Diagnostics.TraceEventType.Information);
                     break;
                 case LogLevel.Verbose:
-                    _logEntry.Log(message, System.Diagnostics.TraceEventType.Verbose);
+                    LogSink.Log(message, System.Diagnostics.TraceEventType.Verbose);
                     break;
                 case LogLevel.Warning:
-                    _logEntry.Log(message, System.Diagnostics.TraceEventType.Warning);
+                    LogSink.Log(message, System.Diagnostics.TraceEventType.Warning);
                     break;
                 case LogLevel.Error:
-                    _logEntry.Log(message, System.Diagnostics.TraceEventType.Error);
+                    LogSink.Log(message, System.Diagnostics.TraceEventType.Error);
                     break;
                 default:
                     break;
+            }
+
+            if (createdLogSource)
+            {
+                LogSink.Dispose();
             }
         }
 

--- a/src/GeneralTools/DataverseClient/Client/Utils/RequestBinderUtil.cs
+++ b/src/GeneralTools/DataverseClient/Client/Utils/RequestBinderUtil.cs
@@ -44,11 +44,23 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Utils
                     }
                     continue;
                 }
+                if (itm.Key == Utilities.RequestHeaders.CALLER_OBJECT_ID_HTTP_HEADER)
+                {
+                    AddorUpdateHeaderProperties(httpRequestMessageHeaders, Utilities.RequestHeaders.CALLER_OBJECT_ID_HTTP_HEADER, itm.Value.ToString());
+                    continue;
+                }
+                if (itm.Key == Utilities.RequestHeaders.AAD_CALLER_OBJECT_ID_HTTP_HEADER)
+                {
+                    AddorUpdateHeaderProperties(httpRequestMessageHeaders, Utilities.RequestHeaders.AAD_CALLER_OBJECT_ID_HTTP_HEADER, itm.Value.ToString());
+                    continue;
+                }
             }
             if ( request.Parameters.Count > 0 )
             {
                 request.Parameters.Remove(Utilities.RequestHeaders.X_MS_CORRELATION_REQUEST_ID);
                 request.Parameters.Remove(Utilities.RequestHeaders.X_MS_CLIENT_SESSION_ID);
+                request.Parameters.Remove(Utilities.RequestHeaders.CALLER_OBJECT_ID_HTTP_HEADER);
+                request.Parameters.Remove(Utilities.RequestHeaders.AAD_CALLER_OBJECT_ID_HTTP_HEADER);
                 request.Parameters.Remove(HEADERLIST);
             }
         }

--- a/src/GeneralTools/DataverseClient/ConnectControl/ServerLoginControl.xaml
+++ b/src/GeneralTools/DataverseClient/ConnectControl/ServerLoginControl.xaml
@@ -211,9 +211,9 @@
                 <Int32AnimationUsingKeyFrames Storyboard.TargetProperty="(KeyboardNavigation.TabIndex)" Storyboard.TargetName="cbUseDefaultCreds">
                     <EasingInt32KeyFrame KeyTime="0" Value="4"/>
                 </Int32AnimationUsingKeyFrames>
-                <Int32AnimationUsingKeyFrames Storyboard.TargetProperty="(KeyboardNavigation.TabIndex)" Storyboard.TargetName="tbDomain">
+                <!--<Int32AnimationUsingKeyFrames Storyboard.TargetProperty="(KeyboardNavigation.TabIndex)" Storyboard.TargetName="tbDomain">
                     <EasingInt32KeyFrame KeyTime="0" Value="8"/>
-                </Int32AnimationUsingKeyFrames>
+                </Int32AnimationUsingKeyFrames>-->
                 <Int32AnimationUsingKeyFrames Storyboard.TargetProperty="(KeyboardNavigation.TabIndex)" Storyboard.TargetName="cbAskforOrg">
                     <EasingInt32KeyFrame KeyTime="0" Value="11"/>
                 </Int32AnimationUsingKeyFrames>

--- a/src/GeneralTools/DataverseClient/ConnectControl/ServerLoginControl.xaml.cs
+++ b/src/GeneralTools/DataverseClient/ConnectControl/ServerLoginControl.xaml.cs
@@ -23,6 +23,7 @@ using Microsoft.PowerPlatform.Dataverse.Client.Model;
 using System.Media;
 using System.Windows.Automation.Peers;
 using System.Security.Policy;
+using Microsoft.PowerPlatform.Dataverse.Client.Utils;
 
 #endregion
 
@@ -260,8 +261,21 @@ namespace Microsoft.PowerPlatform.Dataverse.ConnectControl
 
 			ConnectionManager = connectionManager;
 
-			// Set the CRM Server List here from the UI.. 
-			object oCrmDiscoServices = FindResource("OnlineDiscoveryServersDataSource");
+			
+            bool hideOnPrem = AppSettingsHelper.GetAppSetting<bool>("HideOnPrem", true);
+			if (hideOnPrem)
+			{
+				rbOnPrem.IsEnabled = false; 
+                rbOnPrem.Visibility = Visibility.Collapsed;
+			}
+			else
+			{
+				rbOnPrem.IsEnabled = true;
+				rbOnPrem.Visibility = Visibility.Visible;
+			}
+
+            // Set the CRM Server List here from the UI.. 
+            object oCrmDiscoServices = FindResource("OnlineDiscoveryServersDataSource");
 			if (oCrmDiscoServices != null && oCrmDiscoServices is Model.OnlineDiscoveryServers)
 				ConnectionManager.OnlineDiscoveryServerList = (Model.OnlineDiscoveryServers)oCrmDiscoServices;
 

--- a/src/GeneralTools/DataverseClient/DataverseClientWithConnector.sln
+++ b/src/GeneralTools/DataverseClient/DataverseClientWithConnector.sln
@@ -23,8 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PowerPlatform.Dat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PowerPlatform.Dataverse.WebResourceUtility", "WebResourceUtility\Microsoft.PowerPlatform.Dataverse.WebResourceUtility.csproj", "{FDFD6B7F-A925-40EE-98DC-2E06C1D1E3B6}"
 EndProject
-#Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PowerPlatform.Dataverse.ServiceClientConverter", "Extensions\Microsoft.PowerPlatform.Dataverse.ServiceClientConverter\Microsoft.PowerPlatform.Dataverse.ServiceClientConverter.csproj", "{6F7522A6-3B98-40EE-B92B-5EA423E6F600}"
-#EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.PowerPlatform.Dataverse.Client.AzAuth", "Extensions\Microsoft.PowerPlatform.Dataverse.Client.AzAuth\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.csproj", "{618D52B7-4CE7-402F-972B-E381C1C28299}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		CRMINTERNAL|Any CPU = CRMINTERNAL|Any CPU
@@ -131,18 +131,18 @@ Global
 		{FDFD6B7F-A925-40EE-98DC-2E06C1D1E3B6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FDFD6B7F-A925-40EE-98DC-2E06C1D1E3B6}.Release|x64.ActiveCfg = Release|x64
 		{FDFD6B7F-A925-40EE-98DC-2E06C1D1E3B6}.Release|x64.Build.0 = Release|x64
-		{6F7522A6-3B98-40EE-B92B-5EA423E6F600}.CRMINTERNAL|Any CPU.ActiveCfg = Debug|Any CPU
-		{6F7522A6-3B98-40EE-B92B-5EA423E6F600}.CRMINTERNAL|Any CPU.Build.0 = Debug|Any CPU
-		{6F7522A6-3B98-40EE-B92B-5EA423E6F600}.CRMINTERNAL|x64.ActiveCfg = Debug|Any CPU
-		{6F7522A6-3B98-40EE-B92B-5EA423E6F600}.CRMINTERNAL|x64.Build.0 = Debug|Any CPU
-		{6F7522A6-3B98-40EE-B92B-5EA423E6F600}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6F7522A6-3B98-40EE-B92B-5EA423E6F600}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6F7522A6-3B98-40EE-B92B-5EA423E6F600}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{6F7522A6-3B98-40EE-B92B-5EA423E6F600}.Debug|x64.Build.0 = Debug|Any CPU
-		{6F7522A6-3B98-40EE-B92B-5EA423E6F600}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6F7522A6-3B98-40EE-B92B-5EA423E6F600}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6F7522A6-3B98-40EE-B92B-5EA423E6F600}.Release|x64.ActiveCfg = Release|Any CPU
-		{6F7522A6-3B98-40EE-B92B-5EA423E6F600}.Release|x64.Build.0 = Release|Any CPU
+		{618D52B7-4CE7-402F-972B-E381C1C28299}.CRMINTERNAL|Any CPU.ActiveCfg = Debug|Any CPU
+		{618D52B7-4CE7-402F-972B-E381C1C28299}.CRMINTERNAL|Any CPU.Build.0 = Debug|Any CPU
+		{618D52B7-4CE7-402F-972B-E381C1C28299}.CRMINTERNAL|x64.ActiveCfg = Debug|Any CPU
+		{618D52B7-4CE7-402F-972B-E381C1C28299}.CRMINTERNAL|x64.Build.0 = Debug|Any CPU
+		{618D52B7-4CE7-402F-972B-E381C1C28299}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{618D52B7-4CE7-402F-972B-E381C1C28299}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{618D52B7-4CE7-402F-972B-E381C1C28299}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{618D52B7-4CE7-402F-972B-E381C1C28299}.Debug|x64.Build.0 = Debug|Any CPU
+		{618D52B7-4CE7-402F-972B-E381C1C28299}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{618D52B7-4CE7-402F-972B-E381C1C28299}.Release|Any CPU.Build.0 = Release|Any CPU
+		{618D52B7-4CE7-402F-972B-E381C1C28299}.Release|x64.ActiveCfg = Release|Any CPU
+		{618D52B7-4CE7-402F-972B-E381C1C28299}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/GeneralTools/DataverseClient/Extensions/Microsoft.PowerPlatform.Dataverse.Client.AzAuth/AzAuth.cs
+++ b/src/GeneralTools/DataverseClient/Extensions/Microsoft.PowerPlatform.Dataverse.Client.AzAuth/AzAuth.cs
@@ -1,0 +1,195 @@
+using Azure.Core;
+using Azure.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerPlatform.Dataverse.Client.Model;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerPlatform.Dataverse.Client
+{
+    /// <summary>
+    /// Base auth class to create an authentication client for Az Authentication
+    /// This module will provide a means to create an Dataverse Service Client using Az Authentication
+    /// </summary>
+    public class AzAuth
+    {
+
+        private DefaultAzureCredential _defaultAzureCredential;
+        private DefaultAzureCredentialOptions _credentialOptions;
+        private readonly bool _autoResolveAuthorityAndTenant;
+        private Dictionary<Uri, List<string>> _scopesList;
+        private Dictionary<Uri, AccessToken?> _cacheList;
+        private ILogger _logger;
+
+
+        /// <summary>
+        /// Creates a new instance of the ServiceClient class
+        /// </summary>
+        /// <param name="instanceUrl"></param>
+        /// <param name="autoResolveAuthorityAndTenant"></param>
+        /// <param name="credentialOptions"></param>
+        /// <param name="logger"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        public static ServiceClient CreateServiceClient(string instanceUrl, bool autoResolveAuthorityAndTenant = true, ILogger logger = null, DefaultAzureCredentialOptions credentialOptions = null)
+        {
+            if (!Uri.IsWellFormedUriString(instanceUrl, UriKind.RelativeOrAbsolute))
+            {
+                throw new ArgumentException("Invalid instance URL");
+            }
+            AzAuth azAuth = new AzAuth(autoResolveAuthorityAndTenant, credentialOptions , logger);
+            return new ServiceClient(new Uri(instanceUrl), tokenProviderFunction: azAuth.GetAccessToken, logger: logger);
+        }
+
+        /// <summary>
+        /// Build this based on connection and configuration options. 
+        /// </summary>
+        /// <param name="autoResolveAuthorityAndTenant"></param>
+        /// <param name="connectionOptions"></param>
+        /// <param name="configurationOptions"></param>
+        /// <param name="credentialOptions"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        public static ServiceClient CreateServiceClient(ConnectionOptions connectionOptions, ConfigurationOptions configurationOptions = null, bool autoResolveAuthorityAndTenant = true, DefaultAzureCredentialOptions credentialOptions = null)
+        {
+            if ( connectionOptions == null )
+            {
+                throw new ArgumentException("ConnectionOptions are required");
+            }
+            if (connectionOptions.ServiceUri == null)
+            {
+                throw new ArgumentException("ConnectionOptions.ServiceUri is required");
+            }
+            connectionOptions.AuthenticationType = AuthenticationType.ExternalTokenManagement; // force the authentication type to be external token management.
+
+            AzAuth azAuth = new AzAuth(autoResolveAuthorityAndTenant, credentialOptions, connectionOptions.Logger);
+            connectionOptions.AccessTokenProviderFunctionAsync = azAuth.GetAccessToken;
+            return new ServiceClient(connectionOptions, false, configurationOptions); 
+        }
+
+
+
+        /// <summary>
+        /// Creates a new instance of the AzAuth class
+        /// </summary>
+        /// <param name="autoResolveAuthorityAndTenant"></param>
+        /// <param name="credentialOptions"></param>
+        /// <param name="logger"></param>
+        public AzAuth(bool autoResolveAuthorityAndTenant, DefaultAzureCredentialOptions credentialOptions = null, ILogger logger = null)
+        {
+            _credentialOptions = credentialOptions;
+            _autoResolveAuthorityAndTenant = autoResolveAuthorityAndTenant;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Returns the current access token for the connected ServiceClient instance
+        /// </summary>
+        /// <param name="instanceUrl"></param>
+        /// <returns></returns>
+        public async Task<string> GetAccessToken(string instanceUrl)
+        {
+            if (!Uri.IsWellFormedUriString(instanceUrl, UriKind.RelativeOrAbsolute))
+            {
+                throw new ArgumentException("Invalid instance URL");
+            }
+            AccessToken? accessToken = null; 
+            Uri instanceUri = new Uri(instanceUrl);
+            if (_defaultAzureCredential == null)
+            {
+                Uri resourceUri = await InitializeCredentials(instanceUri).ConfigureAwait(false);
+                ResolveScopesList(instanceUri, resourceUri);
+            }
+
+            // Get or create existing token. 
+            _cacheList ??= new Dictionary<Uri, AccessToken?>();
+            if (_cacheList.ContainsKey(instanceUri))
+            {
+                accessToken = _cacheList[instanceUri];
+                if (accessToken.HasValue && accessToken.Value.ExpiresOn < DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(30)))
+                    accessToken = null; // flush the access token if it is about to expire. 
+            }
+
+            if ( accessToken == null)
+            {
+                Stopwatch sw = Stopwatch.StartNew();
+                _logger.LogDebug("Getting new access token for {0}", instanceUri);
+                accessToken = await _defaultAzureCredential.GetTokenAsync(new Azure.Core.TokenRequestContext(ResolveScopesList(instanceUri))).ConfigureAwait(false);
+                _logger.LogDebug("Access token retrieved in {0}ms", sw.ElapsedMilliseconds);
+                sw.Stop();
+                if(_cacheList.ContainsKey(instanceUri))
+                {
+                    _cacheList[instanceUri] = accessToken;
+                }
+                else
+                {
+                    _cacheList.Add(instanceUri, accessToken);
+                }
+            }
+
+            if (accessToken == null)
+            {
+                throw new Exception("Failed to retrieve access token");
+            }
+
+            return accessToken.Value.Token;
+        }
+
+        private string[] ResolveScopesList(Uri instanceUrl , Uri resource = null)
+        {
+            _scopesList ??= new Dictionary<Uri, List<string>>();
+            if ( _scopesList.ContainsKey(instanceUrl))
+            {
+                return _scopesList[instanceUrl].ToArray();
+            }
+            if (resource == null)
+            {
+                throw new ArgumentNullException("Resource URI is required");
+            }
+            else
+            {
+                _scopesList.Add(instanceUrl, new List<string> { $"{resource}.default" });
+                return _scopesList[instanceUrl].ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Initialize the credentials for the current instance
+        /// </summary>
+        /// <param name="instanceUrl"></param>
+        /// <returns></returns>
+        private async Task<Uri> InitializeCredentials(Uri instanceUrl)
+        {
+            _logger.LogDebug("Initializing credentials for {0}", instanceUrl);
+            Stopwatch sw = Stopwatch.StartNew();
+           
+            Uri resourceUri = null;
+            _credentialOptions ??= new DefaultAzureCredentialOptions();
+
+            if (_autoResolveAuthorityAndTenant)
+            {
+                _logger.LogDebug("Resolving authority and tenant for {0}", instanceUrl);
+                using var httpClient = new System.Net.Http.HttpClient();
+                Auth.AuthorityResolver authorityResolver = new Auth.AuthorityResolver(httpClient);
+                var authDetails = await authorityResolver.ProbeForExpectedAuthentication(instanceUrl).ConfigureAwait(false);
+                resourceUri = authDetails.Resource;
+                _credentialOptions.AuthorityHost = authDetails.Authority;
+                _credentialOptions.TenantId = authDetails.Authority.Segments[1].Replace("/", "");
+
+                _logger.LogDebug("Authority and tenant resolved in {0}ms", sw.ElapsedMilliseconds);
+                _logger.LogDebug("Initialize Creds - found authority with name " + (string.IsNullOrEmpty(authDetails.Authority.ToString()) ? "<Not Provided>" : authDetails.Authority.ToString()));
+                _logger.LogDebug("Initialize Creds - found resource with name " + (string.IsNullOrEmpty(authDetails.Resource.ToString()) ? "<Not Provided>" : authDetails.Resource.ToString()));
+                _logger.LogDebug("Initialize Creds - found tenantId " + (string.IsNullOrEmpty(_credentialOptions.TenantId) ? "<Not Provided>" : _credentialOptions.TenantId));
+            }
+            _defaultAzureCredential = new DefaultAzureCredential(_credentialOptions);
+
+            _logger.LogDebug("Credentials initialized in {0}ms", sw.ElapsedMilliseconds);
+            sw.Start();
+
+            return resourceUri;
+        }
+        
+    }
+}

--- a/src/GeneralTools/DataverseClient/Extensions/Microsoft.PowerPlatform.Dataverse.Client.AzAuth/Microsoft.PowerPlatform.Dataverse.Client.AzAuth.csproj
+++ b/src/GeneralTools/DataverseClient/Extensions/Microsoft.PowerPlatform.Dataverse.Client.AzAuth/Microsoft.PowerPlatform.Dataverse.Client.AzAuth.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<RootNamespace>Microsoft.PowerPlatform.Dataverse.Client.AzAuth</RootNamespace>
+		<ComponentAreaName>DataverseClient</ComponentAreaName>
+		<SignAssembly>true</SignAssembly>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<LangVersion>8.0</LangVersion>
+	</PropertyGroup>
+	<Import Project="..\..\..\..\Build.Common.core.props" />
+
+	<PropertyGroup>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<DocumentationFile>$(OutDir)\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.xml</DocumentationFile>
+		<AnalysisLevel>6.0</AnalysisLevel>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Azure.Identity" Version="$(PackageVersion_Azure_Identity)" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\Client\Microsoft.PowerPlatform.Dataverse.Client.csproj" />
+	</ItemGroup>
+	
+</Project>

--- a/src/GeneralTools/DataverseClient/Testers/LoginControlTester/app.config
+++ b/src/GeneralTools/DataverseClient/Testers/LoginControlTester/app.config
@@ -1,98 +1,104 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <system.diagnostics>
-    <trace autoflush="true" />
-    <sources>
-      <source name="Microsoft.PowerPlatform.Dataverse.ConnectControl" switchName="Microsoft.PowerPlatform.Dataverse.ConnectControl" switchType="System.Diagnostics.SourceSwitch">
-        <listeners>
-          <add name="console" type="System.Diagnostics.DefaultTraceListener" />
-          <remove name="Default" />
-          <add name="fileListener" />
-        </listeners>
-      </source>
+	<system.diagnostics>
+		<trace autoflush="true" />
+		<sources>
+			<source name="Microsoft.PowerPlatform.Dataverse.ConnectControl" switchName="Microsoft.PowerPlatform.Dataverse.ConnectControl" switchType="System.Diagnostics.SourceSwitch">
+				<listeners>
+					<add name="console" type="System.Diagnostics.DefaultTraceListener" />
+					<remove name="Default" />
+					<add name="fileListener" />
+				</listeners>
+			</source>
+			<source name="Microsoft.PowerPlatform.Dataverse.Client.ServiceClient" switchName="Microsoft.PowerPlatform.Dataverse.Client.ServiceClient" switchType="System.Diagnostics.SourceSwitch">
+				<listeners>
+					<add name="console" type="System.Diagnostics.DefaultTraceListener" />
+					<remove name="Default" />
+					<add name="fileListener" />
+				</listeners>
+			</source>
+			<source name="Microsoft.PowerPlatform.Dataverse.WebResourceUtility" switchName="Microsoft.PowerPlatform.Dataverse.WebResourceUtility" switchType="System.Diagnostics.SourceSwitch">
+				<listeners>
+					<add name="console" type="System.Diagnostics.DefaultTraceListener" />
+					<remove name="Default" />
+					<add name="fileListener" />
+				</listeners>
+			</source>
 
-      <source name="Microsoft.PowerPlatform.Dataverse.WebResourceUtility" switchName="Microsoft.PowerPlatform.Dataverse.WebResourceUtility" switchType="System.Diagnostics.SourceSwitch">
-        <listeners>
-          <add name="console" type="System.Diagnostics.DefaultTraceListener" />
-          <remove name="Default" />
-          <add name="fileListener" />
-        </listeners>
-      </source>
-      
-    <!-- WCF DEBUG SOURCES -->
-      <source name="System.IdentityModel" switchName="System.IdentityModel">
-        <listeners>
-          <add name="xml" />
-        </listeners>
-      </source>
-      <!-- Log all messages in the 'Messages' tab of SvcTraceViewer. -->
-      <source name="System.ServiceModel.MessageLogging" switchName="System.ServiceModel.MessageLogging">
-        <listeners>
-          <add name="xml" />
-        </listeners>
-      </source>
-      <!-- ActivityTracing and propogateActivity are used to flesh out the 'Activities' tab in
+			<!-- WCF DEBUG SOURCES -->
+			<source name="System.IdentityModel" switchName="System.IdentityModel">
+				<listeners>
+					<add name="xml" />
+				</listeners>
+			</source>
+			<!-- Log all messages in the 'Messages' tab of SvcTraceViewer. -->
+			<source name="System.ServiceModel.MessageLogging" switchName="System.ServiceModel.MessageLogging">
+				<listeners>
+					<add name="xml" />
+				</listeners>
+			</source>
+			<!-- ActivityTracing and propogateActivity are used to flesh out the 'Activities' tab in
            SvcTraceViewer to aid debugging. -->
-      <source name="System.ServiceModel" switchName="System.ServiceModel" propagateActivity="true">
-        <listeners>
-          <add name="xml" />
-        </listeners>
-      </source>
-      <!-- END WCF DEBUG SOURCES -->
-      <source name="Microsoft.Identity.Client" switchName="Microsoft.Identity.Client" switchType="System.Diagnostics.SourceSwitch">
-        <listeners>
-          <add name="console" type="System.Diagnostics.DefaultTraceListener" />
-          <remove name="Default" />
-          <!--<add name="MSALListener" />-->
-          <add name="fileListener" />
-       </listeners>
-     </source>
-    </sources>
-    <switches>
-      <!-- 
+			<source name="System.ServiceModel" switchName="System.ServiceModel" propagateActivity="true">
+				<listeners>
+					<add name="xml" />
+				</listeners>
+			</source>
+			<!-- END WCF DEBUG SOURCES -->
+			<source name="Microsoft.Identity.Client" switchName="Microsoft.Identity.Client" switchType="System.Diagnostics.SourceSwitch">
+				<listeners>
+					<add name="console" type="System.Diagnostics.DefaultTraceListener" />
+					<remove name="Default" />
+					<!--<add name="MSALListener" />-->
+					<add name="fileListener" />
+				</listeners>
+			</source>
+		</sources>
+		<switches>
+			<!-- 
             Possible values for switches: Off, Error, Warining, Info, Verbose
                 Verbose:    includes Error, Warning, Info, Trace levels
                 Info:       includes Error, Warning, Info levels
                 Warning:    includes Error, Warning levels
                 Error:      includes Error level
         -->
-      <add name="Microsoft.PowerPlatform.Dataverse.Connector.CrmServiceClient" value="Verbose" />
-      <add name="Microsoft.PowerPlatform.Dataverse.ConnectControl" value="Verbose" />
-      <add name="Microsoft.PowerPlatform.Dataverse.WebResourceUtility" value="Verbose" />
-      <add name="System.IdentityModel" value="Verbose" />
-      <add name="System.ServiceModel.MessageLogging" value="Verbose" />
-      <add name="System.ServiceModel" value="Error, ActivityTracing" />
-      <add name="Microsoft.Identity.Client" value="Verbose" />
+			<add name="Microsoft.PowerPlatform.Dataverse.Client.ServiceClient" value="Verbose" />
+			<add name="Microsoft.PowerPlatform.Dataverse.ConnectControl" value="Verbose" />
+			<add name="Microsoft.PowerPlatform.Dataverse.WebResourceUtility" value="Verbose" />
+			<add name="System.IdentityModel" value="Verbose" />
+			<add name="System.ServiceModel.MessageLogging" value="Verbose" />
+			<add name="System.ServiceModel" value="Error, ActivityTracing" />
+			<add name="Microsoft.Identity.Client" value="Verbose" />
 
-    </switches>
-    <sharedListeners>
-      <add name="fileListener" type="System.Diagnostics.TextWriterTraceListener" initializeData="LoginControlTesterLog.txt" />
-      <!--<add name="eventLogListener" type="System.Diagnostics.EventLogTraceListener" initializeData="CRM UII"/>-->
-      <add name="xml" type="System.Diagnostics.XmlWriterTraceListener" initializeData="CrmToolBox.svclog" />
-      <add name="MSALListener" type="Microsoft.PowerPlatform.Dataverse.Connector.DynamicsFileLogTraceListener, Microsoft.PowerPlatform.Dataverse.Connector" BaseFileName="ADAL" Location="LocalUserApplicationDirectory" MaxFileSize="52428800" />
-    </sharedListeners>
-  </system.diagnostics>
+		</switches>
+		<sharedListeners>
+			<add name="fileListener" type="System.Diagnostics.TextWriterTraceListener" initializeData="LoginControlTesterLog.txt" />
+			<!--<add name="eventLogListener" type="System.Diagnostics.EventLogTraceListener" initializeData="CRM UII"/>-->
+			<add name="xml" type="System.Diagnostics.XmlWriterTraceListener" initializeData="CrmToolBox.svclog" />
+			<add name="MSALListener" type="Microsoft.PowerPlatform.Dataverse.Connector.DynamicsFileLogTraceListener, Microsoft.PowerPlatform.Dataverse.Connector" BaseFileName="ADAL" Location="LocalUserApplicationDirectory" MaxFileSize="52428800" />
+		</sharedListeners>
+	</system.diagnostics>
 
-  <appSettings>
-    <!--<add key="SkipDiscovery" value="true"/>-->
+	<appSettings>
+		<!--<add key="SkipDiscovery" value="true"/>-->
 
-    <!-- Used for in memory log collection -->
-    <!--
+		<!-- Used for in memory log collection -->
+		<!--
       <add key="InMemoryLogCollectionEnabled" value="false"/>
       <add key="InMemoryLogCollectionTimeOutMinutes" value="1"/>
     -->
-    <add key="MSALLogPII" value="true" />
-  </appSettings>
-  
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
-  </startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+		<add key="MSALLogPII" value="true" />
+	</appSettings>
+
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+	</startup>
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
 </configuration>

--- a/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/AzAuthExtentionTests.cs
+++ b/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/AzAuthExtentionTests.cs
@@ -1,0 +1,64 @@
+using Client_Core_UnitTests;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Dataverse.Client.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DataverseClient_Core_UnitTests
+{
+    public class AzAuthExtentionTests
+    {
+        TestSupport testSupport = new TestSupport();
+        public AzAuthExtentionTests(ITestOutputHelper output)
+        {
+            IConfiguration config = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .Build();
+
+
+
+            ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
+                    builder.AddConsole(options =>
+                    {
+                        options.IncludeScopes = true;
+                        options.TimestampFormat = "hh:mm:ss ";
+                    })
+                    .AddConfiguration(config.GetSection("Logging"))
+                    .AddProvider(new TraceConsoleLoggingProvider(output)));
+            testSupport.logger = loggerFactory.CreateLogger<ClientDynamicsExtensionsTests>();
+        }
+
+        //[SkippableConnectionTest]
+        //[Fact]
+        [Trait("Category", "Live Connect Required")]
+        public void CreateServiceClient()
+        {
+            //var client = AzAuth.CreateServiceClient("<orgA>", true);
+            //var client = AzAuth.CreateServiceClient("<orgB>", true);
+            var client = AzAuth.CreateServiceClient(new ConnectionOptions()
+            {
+                ServiceUri = new Uri("<orgC>"),
+                Logger = testSupport.logger
+            });
+
+            Assert.NotNull(client);
+
+            var rslt = client.Execute(new WhoAmIRequest());
+            Assert.NotNull(rslt);
+            Assert.IsType<WhoAmIResponse>(rslt);
+
+            var rlst1 = client.Execute(new RetrieveCurrentOrganizationRequest() { AccessType = 0});
+            Assert.NotNull(rlst1);
+            Assert.IsType<RetrieveCurrentOrganizationResponse>(rlst1);
+
+        }
+    }
+}

--- a/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/DataverseClient_Core_UnitTests.csproj
+++ b/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/DataverseClient_Core_UnitTests.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Client\Microsoft.PowerPlatform.Dataverse.Client.csproj" />
     <ProjectReference Include="..\..\Extensions\DynamicsExtension\Microsoft.PowerPlatform.Dataverse.Client.Dynamics.csproj" />
+    <ProjectReference Include="..\..\Extensions\Microsoft.PowerPlatform.Dataverse.Client.AzAuth\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/ServiceClientTests.cs
+++ b/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/ServiceClientTests.cs
@@ -1771,7 +1771,11 @@ namespace Client_Core_Tests
 
             var trackingId = a.Id;
 
-            var rslt = await client.CreateRequestBuilder().WithCorrelationId(Guid.NewGuid()).WithHeader("User-Agent", "TEST").WithHeader("Foo", "TEST1").CreateAsync(a).ConfigureAwait(false);
+            var rslt = await client.CreateRequestBuilder()
+                .WithCorrelationId(Guid.NewGuid())
+                .WithHeader("User-Agent", "TEST")
+                .WithHeader("Foo", "TEST1")
+                .CreateAsync(a).ConfigureAwait(false);
             Assert.IsType<Guid>(rslt);
 
             a["name"] = "Test Account - step 2";

--- a/src/Packages.props
+++ b/src/Packages.props
@@ -1,0 +1,33 @@
+<Project>
+    <!-- This file is used for controling versions of packages for projects in this repo, it is also used to populate dependnaices in Nuspec files.-->
+    <PropertyGroup Label="Package versions">
+        <PackageVersion_Adal>3.19.8</PackageVersion_Adal>
+        <PackageVersion_MSAL>4.61.3</PackageVersion_MSAL>
+        <PackageVersion_CdsSdk>9.2.24044.9795-master</PackageVersion_CdsSdk>
+        <PackageVersion_CrmProxy>9.2.24044.9795-master</PackageVersion_CrmProxy>
+        <PackageVersion_Newtonsoft>13.0.1</PackageVersion_Newtonsoft>
+        <PackageVersion_RestClientRuntime>2.3.24</PackageVersion_RestClientRuntime>
+        <PackageVersion_XrmSdk>9.0.2.55</PackageVersion_XrmSdk>
+        <PackageVersion_Dep_OutlookXrmSdk>9.0.2.34</PackageVersion_Dep_OutlookXrmSdk>
+        <PackageVersion_BatchedTelemetry>3.0.8</PackageVersion_BatchedTelemetry>
+        <PackageVersion_DataverseClient>1.1.22</PackageVersion_DataverseClient>
+        <PackageVersion_CoverletCollector>3.1.0</PackageVersion_CoverletCollector>
+        <PackageVersion_Microsoft_Extensions>3.1.8</PackageVersion_Microsoft_Extensions>
+        <PackageVersion_SystemRuntime>6.0.0</PackageVersion_SystemRuntime>
+        <PackageVersion_SystemTextJson>7.0.3</PackageVersion_SystemTextJson>
+        <PackageVersion_SystemTextEncodingsWeb>7.0.0</PackageVersion_SystemTextEncodingsWeb>
+        <PackageVersion_SystemMemory>4.5.5</PackageVersion_SystemMemory>
+        <PackageVersion_SystemServiceModelHttp>4.10.3</PackageVersion_SystemServiceModelHttp>
+        <PackageVersion_SystemConfigurationConfigurationManager>6.0.0</PackageVersion_SystemConfigurationConfigurationManager>
+        <PackageVersion_SystemSecurityPermissions>6.0.0</PackageVersion_SystemSecurityPermissions>
+        <PackageVersion_Azure_Identity>1.12.0</PackageVersion_Azure_Identity>
+
+        <!-- Test: -->
+        <PackageVersion_MicrosoftNETTestSdk>17.5.0</PackageVersion_MicrosoftNETTestSdk>
+        <PackageVersion_MSTest>2.2.10</PackageVersion_MSTest>
+        <PackageVersion_Moq>4.16.0</PackageVersion_Moq>
+        <PackageVersion_XUnit>2.5.0</PackageVersion_XUnit>
+        <PackageVersion_XUnitRunnerVS>2.5.0</PackageVersion_XUnitRunnerVS>
+        <PackageVersion_FluentAssertions>6.12.0</PackageVersion_FluentAssertions>
+    </PropertyGroup>
+</Project>

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.AzAuth.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.AzAuth.ReleaseNotes.txt
@@ -1,0 +1,9 @@
+Notice: 
+    This package is an extension to the Microsoft.PowerPlatform.Dataverse.Client Nuget package.
+    This package is intended to work with .net full framework 4.6.2, 4.7.2 and 4.8, and .net 6.0
+
+++CURRENTRELEASEID++
+Initial release
+Provides an extension to the Dataverse ServiceClient to support authenticating with the Azure.Core DefaultAzureCredential flow. 
+        
+

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.AzAuth.nuspec
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.AzAuth.nuspec
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.PowerPlatform.Dataverse.Client.AzAuth</id>
+    <version>1.0.0</version>
+    <authors>Microsoft</authors>
+    <owners>crmsdk,Microsoft</owners>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=2108407</licenseUrl>
+    <projectUrl>https://github.com/microsoft/PowerPlatform-DataverseServiceClient</projectUrl>
+    <icon>images\Dataverse.128x128.png</icon>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>This package contains a auth extention for the Dataverse ServiceClient. This extention add support for authentication use the Azure.Core Library. This support the "DefaultAzureCredential" flow. This Package has been authored by the Microsoft Dataverse SDK team.</description>
+    <summary>This package contains a auth extention for the Dataverse ServiceClient. This extention add support for authentication use the Azure.Core Library.</summary>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>Dynamics CommonDataService CDS PowerApps PowerPlatform ServiceClient Dataverse</tags>
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.2">
+        <dependency id="Microsoft.PowerPlatform.Dataverse.Client" version="1.1.0" exclude="Build,Analyzers" />
+        <dependency id="Azure.Identity" version="1.11.3" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETFramework4.7.2">
+        <dependency id="Microsoft.PowerPlatform.Dataverse.Client" version="1.1.0" exclude="Build,Analyzers" />
+        <dependency id="Azure.Identity" version="1.11.3" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETFramework4.8">
+        <dependency id="Microsoft.PowerPlatform.Dataverse.Client" version="1.1.0" exclude="Build,Analyzers" />
+        <dependency id="Azure.Identity" version="1.11.3" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="NET6.0">
+        <dependency id="Microsoft.PowerPlatform.Dataverse.Client" version="1.1.0" exclude="Build,Analyzers" />
+        <dependency id="Azure.Identity" version="1.11.3" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="{signedBinDir}\{configuration}\DataverseClient-AzAuth\net6.0\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.dll" target="lib\net6.0\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.dll" />
+    <file src="{signedBinDir}\{configuration}\DataverseClient-AzAuth\net6.0\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.xml" target="lib\net6.0\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.xml" />
+    <file src="{signedBinDir}\{configuration}\DataverseClient-AzAuth\net472\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.dll" target="lib\net472\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.dll" />
+    <file src="{signedBinDir}\{configuration}\DataverseClient-AzAuth\net472\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.xml" target="lib\net472\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.xml" />
+    <file src="{signedBinDir}\{configuration}\DataverseClient-AzAuth\net462\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.dll" target="lib\net462\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.dll" />
+    <file src="{signedBinDir}\{configuration}\DataverseClient-AzAuth\net462\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.xml" target="lib\net462\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.xml" />
+    <file src="{signedBinDir}\{configuration}\DataverseClient-AzAuth\net48\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.dll" target="lib\net48\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.dll" />
+    <file src="{signedBinDir}\{configuration}\DataverseClient-AzAuth\net48\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.xml" target="lib\net48\Microsoft.PowerPlatform.Dataverse.Client.AzAuth.xml" />
+    <file src="{sharedImagesDir}\Desktop\Dataverse.128x128.png" target="images\Dataverse.128x128.png" />
+  </files>
+</package>

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
@@ -7,6 +7,16 @@ Notice:
     Note: Only AD on FullFramework, OAuth, Certificate, ClientSecret Authentication types are supported at this time.
 
 ++CURRENTRELEASEID++
+Fix for Logging MSAL telemetry when using ILogger
+    Previously, Logs for MSAL were not written to the configured ILogger, they would only go to Trace Source and InMemory Logs.
+Fix for RequestBuilder to properly honor CrmUserId and AADOid in request builder requests. 
+Updated ServiceClient retry logic to use the server specified RetryAfter for Time and Concurrency throttling fault codes, in addition to Burst.
+Updated ConnectionService retry logic to parse RetryAfter header as seconds instead of hours.
+Dependency Changes:
+    Modified:
+        Microsoft.Identity.Client to 4.61.3
+
+1.1.22:
 Fix for Retry hang introduced in 1.1.21:
 Dependency Changes:
     Added: 


### PR DESCRIPTION
Fix for Logging MSAL telemetry when using ILogger
   Previously, Logs for MSAL were not written to the configured ILogger, they would only go to Trace Source and InMemory Logs.
Fix for RequestBuilder to properly honor CrmUserId and AADOid in request builder requests.
Updated ServiceClient retry logic to use the server specified RetryAfter for Time and Concurrency throttling fault codes, in addition to Burst.
Updated ConnectionService retry logic to parse RetryAfter header as seconds instead of hours.
Dependency Changes:
   Modified:
       Microsoft.Identity.Client to 4.61.3

Added initial Azure Auth extensions. 
Packages and added new WPF Login control for Dataverse ServiceClient.