### PR TITLE
Minor bug fixes and dependency updates

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/Builder/AbstractClientRequestBuilder.cs
+++ b/src/GeneralTools/DataverseClient/Client/Builder/AbstractClientRequestBuilder.cs
@@ -135,9 +135,15 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Builder
             }
 
             ParameterCollection parameters = new ParameterCollection();
-            Guid requestTracker = _requestId ?? Guid.NewGuid();
-            request.RequestId = requestTracker;
-            
+
+            if (_requestId != null)
+            {
+                request.RequestId = _requestId.Value;
+            }
+            else if (request.RequestId == null || request.RequestId == Guid.Empty)
+            {
+                request.RequestId = Guid.NewGuid();
+            }
 
             if (_correlationId != null)
             {

--- a/src/GeneralTools/DataverseClient/Client/Microsoft.PowerPlatform.Dataverse.Client.csproj
+++ b/src/GeneralTools/DataverseClient/Client/Microsoft.PowerPlatform.Dataverse.Client.csproj
@@ -36,7 +36,7 @@
 		<PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="$(PackageVersion_Newtonsoft)" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="$(PackageVersion_SystemConfigurationConfigurationManager)" />
-		<PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+		<PackageReference Include="System.Formats.Asn1" Version="$(PackageVersion_System_Formats_Asn1)" />
 		<PackageReference Include="System.Text.Json" Version="$(PackageVersion_SystemTextJson)" />
 		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="$(PackageVersion_MSAL)" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(PackageVersion_Microsoft_Extensions)" />

--- a/src/GeneralTools/DataverseClient/Extensions/DynamicsExtension/Microsoft.PowerPlatform.Dataverse.Client.Dynamics.csproj
+++ b/src/GeneralTools/DataverseClient/Extensions/DynamicsExtension/Microsoft.PowerPlatform.Dataverse.Client.Dynamics.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Xrm.Sdk" Version="$(PackageVersion_CdsSdk)" />
 	<PackageReference Include="Microsoft.Crm.Sdk.Proxy" Version="$(PackageVersion_CrmProxy)" />
-	<PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+	<PackageReference Include="System.Formats.Asn1" Version="$(PackageVersion_System_Formats_Asn1)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GeneralTools/DataverseClient/Extensions/Microsoft.PowerPlatform.Dataverse.ServiceClientConverter/Microsoft.PowerPlatform.Dataverse.ServiceClientConverter.csproj
+++ b/src/GeneralTools/DataverseClient/Extensions/Microsoft.PowerPlatform.Dataverse.ServiceClientConverter/Microsoft.PowerPlatform.Dataverse.ServiceClientConverter.csproj
@@ -16,5 +16,6 @@
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.CrmSdk.XrmTooling.CoreAssembly" Version="9.1.*" />
 	  <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.*" />
+	  <PackageReference Include="System.Text.Json" Version="$(PackageVersion_SystemTextJson)" />
 	</ItemGroup>
 </Project>

--- a/src/Packages.props
+++ b/src/Packages.props
@@ -2,9 +2,9 @@
     <!-- This file is used for controling versions of packages for projects in this repo, it is also used to populate dependnaices in Nuspec files.-->
     <PropertyGroup Label="Package versions">
         <PackageVersion_Adal>3.19.8</PackageVersion_Adal>
-        <PackageVersion_MSAL>4.61.3</PackageVersion_MSAL>
-        <PackageVersion_CdsSdk>9.2.24073.11611-master</PackageVersion_CdsSdk>
-        <PackageVersion_CrmProxy>9.2.24073.11611-master</PackageVersion_CrmProxy>
+        <PackageVersion_MSAL>4.66.1</PackageVersion_MSAL>
+        <PackageVersion_CdsSdk>9.2.25021.14828-master</PackageVersion_CdsSdk>
+        <PackageVersion_CrmProxy>9.2.25021.14828-master</PackageVersion_CrmProxy>
         <PackageVersion_Newtonsoft>13.0.1</PackageVersion_Newtonsoft>
         <PackageVersion_RestClientRuntime>2.3.24</PackageVersion_RestClientRuntime>
         <PackageVersion_XrmSdk>9.0.2.56</PackageVersion_XrmSdk>
@@ -14,14 +14,15 @@
         <PackageVersion_CoverletCollector>3.1.0</PackageVersion_CoverletCollector>
         <PackageVersion_Microsoft_Extensions>3.1.8</PackageVersion_Microsoft_Extensions>
         <PackageVersion_SystemRuntime>6.0.0</PackageVersion_SystemRuntime>
-        <PackageVersion_SystemTextJson>8.0.4</PackageVersion_SystemTextJson>
+        <PackageVersion_SystemTextJson>8.0.5</PackageVersion_SystemTextJson>
         <PackageVersion_SystemTextEncodingsWeb>7.0.0</PackageVersion_SystemTextEncodingsWeb>
         <PackageVersion_SystemMemory>4.5.5</PackageVersion_SystemMemory>
         <PackageVersion_SystemConfigurationConfigurationManager>6.0.0</PackageVersion_SystemConfigurationConfigurationManager>
         <PackageVersion_SystemSecurityPermissions>6.0.0</PackageVersion_SystemSecurityPermissions>
-        <PackageVersion_Azure_Identity>1.12.0</PackageVersion_Azure_Identity>
+        <PackageVersion_Azure_Identity>1.13.1</PackageVersion_Azure_Identity>
         <PackageVersion_System_ServiceModel_PreNet6>4.10.3</PackageVersion_System_ServiceModel_PreNet6>
         <PackageVersion_System_ServiceModel_PostNet6>6.2.0</PackageVersion_System_ServiceModel_PostNet6>
+        <PackageVersion_System_Formats_Asn1>8.0.1</PackageVersion_System_Formats_Asn1>
 
         <!-- Test: -->
         <PackageVersion_MicrosoftNETTestSdk>17.5.0</PackageVersion_MicrosoftNETTestSdk>

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.AzAuth.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.AzAuth.ReleaseNotes.txt
@@ -3,6 +3,10 @@ Notice:
     This package is intended to work with .net full framework 4.6.2, 4.7.2 and 4.8, and .net 6.0
 
 ++CURRENTRELEASEID++
+Dependency changes:
+    Azure.Identity updated to 1.31.1
+
+1.1.10:
 Initial release
 Provides an extension to the Dataverse ServiceClient to support authenticating with the Azure.Core DefaultAzureCredential flow. 
         

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.Dynamics.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.Dynamics.ReleaseNotes.txt
@@ -3,6 +3,8 @@ Notice:
     This package is intended to work with .net full framework 4.6.2, 4.7.2 and 4.8, and .net 6.0
 
 ++CURRENTRELEASEID++
+
+
 removed support for .net 3.1 and .net 5.0. 
 
 1.0.39:

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
@@ -7,11 +7,19 @@ Notice:
     Note: Only AD on FullFramework, OAuth, Certificate, ClientSecret Authentication types are supported at this time.
 
 ++CURRENTRELEASEID++
+RequestId on OrganizationRequest is not overridden by random Guid if present. RequestId from ClientRequestBuilder still takes precedence over OrganizationRequest.RequestId
+Dependency changes:
+    Microsoft.Identity.Client updated to 4.66.1
+    System.Text.Json updated to 8.0.5
+    Azure.Identity updated to 1.31.1
+
+
+1.2.2: 
 ***** POSSIBLE Breaking Changes *****
     Minor Release Bump, 
         Added .net 8.0 Target. 
         .net 6.0 Target will be removed in a subsequent release. 
-    Removed dependance on Microsoft.Rest.Client.  this was primary used for exception handling, and the necessary components have been reworked in to DVSC Exception management classes.
+    Removed dependence on Microsoft.Rest.Client.  this was primary used for exception handling, and the necessary components have been reworked in to DVSC Exception management classes.
 
 Fix memory consumption when too many exception are throw by DV client. Git: https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/474
 Dependency Changes:


### PR DESCRIPTION
RequestId on OrganizationRequest is not overridden by random Guid if present. RequestId from ClientRequestBuilder still takes precedence over OrganizationRequest.RequestId
Dependency changes:
    Microsoft.Identity.Client updated to 4.66.1
    System.Text.Json updated to 8.0.5
    Azure.Identity updated to 1.31.1


### Dependency Updates:

* Updated `System.Formats.Asn1` package version to be controlled by `PackageVersion_System_Formats_Asn1` in `src/GeneralTools/DataverseClient/Client/Microsoft.PowerPlatform.Dataverse.Client.csproj` and `src/GeneralTools/DataverseClient/Extensions/DynamicsExtension/Microsoft.PowerPlatform.Dataverse.Client.Dynamics.csproj` [[1]](diffhunk://#diff-c7de0b2afb480873c1624871753b95ecade7f835ca3ca43263ce5ce598ef9cd3L39-R39) [[2]](diffhunk://#diff-0e09e5e1b5109b9a44d67a77e9b0298aa404c8e843693382e4f95d29187fccaeL18-R18).
* Added `System.Text.Json` package reference in `src/GeneralTools/DataverseClient/Extensions/Microsoft.PowerPlatform.Dataverse.ServiceClientConverter/Microsoft.PowerPlatform.Dataverse.ServiceClientConverter.csproj`.
* Updated multiple package versions in `src/Packages.props`, including `MSAL`, `CdsSdk`, `CrmProxy`, `SystemTextJson`, and `Azure_Identity` [[1]](diffhunk://#diff-8216e3e1d7333aaa683b0550a34cbb9182077907f3d0b2b257c84d23fa08b592L5-R7) [[2]](diffhunk://#diff-8216e3e1d7333aaa683b0550a34cbb9182077907f3d0b2b257c84d23fa08b592L17-R25).

### Code Improvements:

* Improved handling of `RequestId` in `internal OrganizationRequest BuildRequest(OrganizationRequest request)` in `src/GeneralTools/DataverseClient/Client/Builder/AbstractClientRequestBuilder.cs` to avoid overriding `RequestId` if it is already present.

### Release Notes:

* Updated release notes in `src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.AzAuth.ReleaseNotes.txt` to reflect dependency changes including `Azure.Identity` update.
* Updated release notes in `src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.Dynamics.ReleaseNotes.txt` to remove support for .NET 3.1 and .NET 5.0.
* Updated release notes in `src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt` to document changes in `RequestId` handling and multiple dependency updates.