### PR TITLE
Minor fix for CancellationToken handling between retries

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
+++ b/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
@@ -2383,7 +2383,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                         retry = ShouldRetryWebAPI(ex, retryCount, maxRetryCount, retryPauseTime, out isThrottled);
                         if (retry)
                         {
-                            retryCount = await Utilities.RetryRequest(null, requestTrackingId, TimeSpan.Zero, logDt, logEntry, SessionTrackingId, disableConnectionLocking, _retryPauseTimeRunning, ex, errorStringCheck, retryCount, isThrottled, webUriReq: $"{method} {queryString}").ConfigureAwait(false);
+                            retryCount = await Utilities.RetryRequest(null, requestTrackingId, TimeSpan.Zero, logDt, logEntry, SessionTrackingId, disableConnectionLocking, _retryPauseTimeRunning, ex, errorStringCheck, retryCount, isThrottled, webUriReq: $"{method} {queryString}", cancellationToken).ConfigureAwait(false);
                         }
                         else
                         {

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
@@ -7,6 +7,9 @@ Notice:
     Note: Only AD on FullFramework, OAuth, Certificate, ClientSecret Authentication types are supported at this time.
 
 ++CURRENTRELEASEID++
+Fix for CancellationToken not canceling retries during delays Git: https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/508
+
+1.2.5
 Fix for Null ILogger passed to the AzAuth Client Creators causing a fault.  Git: https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/481
 Fix for Memory Leak in Retrieve Multiple. Git: https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/463
 Fix for Memory bloat issue caused by not releasing lastErrorMessage property. 


### PR DESCRIPTION
### Code Improvements: 

- Added `CancellationToken` support and parameter to `internal static async Task<int> RetryRequest(OrganizationRequest req, [...])` in `src/GeneralTools/DataverseClient/Client/Utils/Utils.cs` to cancel the `Task.Delay` between request retries.
- Updated `internal async Task<OrganizationResponse> Command_ExecuteAsyncImpl(OrganizationRequest req, [...])` in `src/GeneralTools/DataverseClient/Client/ServiceClient.cs` to properly throw a`OperationCanceledException` when the `CancelaltionToken` is cancelled, including a race condition where the cancellation could occur within the `catch` 