### PR TITLE
Resolve bug in Cancelation Token comparison 

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/ServiceClient.cs
+++ b/src/GeneralTools/DataverseClient/Client/ServiceClient.cs
@@ -1876,7 +1876,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                 catch (Exception ex)
                 {
                     bool isThrottled = false;
-                    retry = ShouldRetry(req, ex, retryCount, out isThrottled) || !cancellationToken.IsCancellationRequested;
+                    retry = ShouldRetry(req, ex, retryCount, out isThrottled) && !cancellationToken.IsCancellationRequested;
                     if (retry)
                     {
                         retryCount = await Utilities.RetryRequest(req, requestTrackingId, LockWait, logDt, _logEntry, SessionTrackingId, _disableConnectionLocking, _retryPauseTimeRunning, ex, errorStringCheck, retryCount, isThrottled, cancellationToken: cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
This pull request includes a minor but important fix in the `Command_ExecuteAsyncImpl` method of the `ServiceClient` class. The change ensures that retries are only attempted if the cancellation token has not been requested.

* **Retry logic adjustment**:
  - Modified the retry condition in `Command_ExecuteAsyncImpl` to use a logical AND (`&&`) instead of OR (`||`), ensuring retries only occur when the cancellation token has not been requested. (`src/GeneralTools/DataverseClient/Client/ServiceClient.cs`, [src/GeneralTools/DataverseClient/Client/ServiceClient.csL1879-R1879](diffhunk://#diff-805f016427fb0fbb244dc4571694ec793f029f25b3976f5f6c0782ce94631e0bL1879-R1879))

Fixed #511 