### PR TITLE
Added UseExponentialRetryDelayForConcurrencyThrottle configuration option

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/Model/ConfigurationOptions.cs
+++ b/src/GeneralTools/DataverseClient/Client/Model/ConfigurationOptions.cs
@@ -33,6 +33,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Model
                 RetryPauseTime = options.RetryPauseTime;
                 UseWebApi = options.UseWebApi;
                 UseWebApiLoginFlow = options.UseWebApiLoginFlow;
+                UseExponentialRetryDelayForConcurrencyThrottle = options.UseExponentialRetryDelayForConcurrencyThrottle;
             }
         }
 
@@ -69,6 +70,17 @@ namespace Microsoft.PowerPlatform.Dataverse.Client.Model
         {
             get => _useWebApi;
             set => _useWebApi = value;
+        }
+
+        private bool _useExponentialRetryDelayForConcurrencyThrottle = Utils.AppSettingsHelper.GetAppSetting<bool>("UseExponentialRetryDelayForConcurrencyThrottle", false);
+
+        /// <summary>
+        /// Use exponential retry delay for concurrency throttling instead of server specified Retry-After header
+        /// </summary>
+        public bool UseExponentialRetryDelayForConcurrencyThrottle
+        {
+            get => _useExponentialRetryDelayForConcurrencyThrottle;
+            set => _useExponentialRetryDelayForConcurrencyThrottle = value;
         }
 
         private bool _useWebApiLoginFlow = Utils.AppSettingsHelper.GetAppSetting<bool>("UseWebApiLoginFlow", true);

--- a/src/GeneralTools/DataverseClient/Extensions/Microsoft.PowerPlatform.Dataverse.Client.AzAuth/AzAuth.cs
+++ b/src/GeneralTools/DataverseClient/Extensions/Microsoft.PowerPlatform.Dataverse.Client.AzAuth/AzAuth.cs
@@ -190,6 +190,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
                 _logger.LogDebug("Initialize Creds - found resource with name " + (string.IsNullOrEmpty(authDetails.Resource.ToString()) ? "<Not Provided>" : authDetails.Resource.ToString()));
                 _logger.LogDebug("Initialize Creds - found tenantId " + (string.IsNullOrEmpty(_credentialOptions.TenantId) ? "<Not Provided>" : _credentialOptions.TenantId));
             }
+            // CodeQL [SM05137] Not applicable - this is a Public client SDK
             _defaultAzureCredential = new DefaultAzureCredential(_credentialOptions);
 
             _logger.LogDebug("Credentials initialized in {0}ms", sw.ElapsedMilliseconds);

--- a/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/ServiceClientTests.cs
+++ b/src/GeneralTools/DataverseClient/UnitTests/CdsClient_Core_Tests/ServiceClientTests.cs
@@ -884,6 +884,18 @@ namespace Client_Core_Tests
             testwatch.Elapsed.Should().BeLessThan(delay, "Task should return before its delay timer can complete due to cancellation");
         }
 
+        [Fact]
+        public void TestOptionUseExponentialRetryDelayForConcurrencyThrottle()
+        {
+            testSupport.SetupMockAndSupport(out var orgSvc, out var fakHttpMethodHander, out var cli);
+            cli.UseExponentialRetryDelayForConcurrencyThrottle = true;
+
+            var rsp = (WhoAmIResponse)cli.ExecuteOrganizationRequest(new WhoAmIRequest());
+
+            // Validate that the behavior remains unchanged when the option UseExponentialRetryDelayForConcurrencyThrottle is set to true.
+            Assert.Equal(rsp.UserId, testSupport._UserId);
+        }
+
         #region LiveConnectedTests
 
         [SkippableConnectionTest]

--- a/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.PowerPlatform.Dataverse.Client.ReleaseNotes.txt
@@ -7,6 +7,9 @@ Notice:
     Note: Only AD on FullFramework, OAuth, Certificate, ClientSecret Authentication types are supported at this time.
 
 ++CURRENTRELEASEID++
+Add a new configuration option UseExponentialRetryDelayForConcurrencyThrottle to use exponential retry delay for concurrency throttling, instead of the server-specified Retry-After header where applicable. Default is False.
+
+1.2.7
 Fix for CancellationToken not canceling retries during delays Git: https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/508
 
 1.2.5


### PR DESCRIPTION
This pull request introduces a new configuration switch `UseExponentialRetryDelayForConcurrencyThrottle` which causes the retry logic to use the exponential retry delay behavior for concurrency throttling instead of the `Retry-After` header's value.  Default value is false.