### PR TITLE
Enabling non-standard ports for on-prem using OAuth

### DIFF
--- a/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
+++ b/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
@@ -1473,11 +1473,11 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
             Uri OrgWorkingURI = null;
             if (!IsOnPrem)
             {
-                OrgWorkingURI = new Uri(string.Format(SoapOrgUriFormat, _targetInstanceUriToConnectTo.Scheme, _targetInstanceUriToConnectTo.DnsSafeHost));
+                OrgWorkingURI = new Uri(string.Format(SoapOrgUriFormat, _targetInstanceUriToConnectTo.Scheme, _targetInstanceUriToConnectTo.Authority));
             }
             else
             {
-                OrgWorkingURI = new Uri(string.Format(SoapOrgUriFormat, _targetInstanceUriToConnectTo.Scheme, $"{_targetInstanceUriToConnectTo.DnsSafeHost}/{_organization}"));
+                OrgWorkingURI = new Uri(string.Format(SoapOrgUriFormat, _targetInstanceUriToConnectTo.Scheme, $"{_targetInstanceUriToConnectTo.Authority}/{_organization}"));
             }
             _targetInstanceUriToConnectTo = OrgWorkingURI;
 

--- a/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
+++ b/src/GeneralTools/DataverseClient/Client/ConnectionService.cs
@@ -1471,7 +1471,7 @@ namespace Microsoft.PowerPlatform.Dataverse.Client
 
             IOrganizationService dvService = null;
             Uri OrgWorkingURI = null;
-            if (!IsOnPrem || _eAuthType == AuthenticationType.OAuth) // Use this even if its onPrem, when auth type == oauth. 
+            if (!IsOnPrem)
             {
                 OrgWorkingURI = new Uri(string.Format(SoapOrgUriFormat, _targetInstanceUriToConnectTo.Scheme, _targetInstanceUriToConnectTo.DnsSafeHost));
             }


### PR DESCRIPTION
Hello my team has been struggling adopt the new ServiceClient as we're very restricted with our old on-prem setup. We've made some advances, and are getting closer, however the best thing we can do is use the ServiceClient constructior that takes url and tokenProviderFunction. This is really the best way for us to use new ServiceClient + OAuth we've set up, however it rewrites our port 444 to 443 and that breaks the client. Thank you for considering this fix.